### PR TITLE
main.py: add link for get_whoami() in py jenkins

### DIFF
--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -72,6 +72,7 @@ class RHCephPkg(object):
         # python-jenkins does not have syntactic support for "whoami" (the
         # "/me/api/json" endpoint), so we have to hit it and parse it
         # ourselves.
+        # https://review.openstack.org/307896
 
         whoami_url = posixpath.join(self.config['jenkins_url'], 'me/api/json')
         try:


### PR DESCRIPTION
Add a comment as a pointer to the work-in-progress get_whoami() function in python-jenkins. When it eventually lands in a stable python-jenkins release, we can use that function instead of our custom code here.