### PR TITLE
localbuild(): limit -j argument according to RAM

### DIFF
--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -1,3 +1,4 @@
+import math
 import logging
 import os
 import posixpath
@@ -128,7 +129,8 @@ class RHCephPkg(object):
         """ Build a package on the local system, using pbuilder. """
         pkg_name = os.path.basename(os.getcwd())
         os.environ['BUILDER'] = 'pbuilder'
-        j_arg = '-j%d' % self._get_num_cpus()
+        cpus = self._get_num_cpus()
+        j_arg = self._get_j_arg(cpus)
         # FIXME: stop hardcoding trusty. Use the git branch name instead,
         # translating "-ubuntu" into this local computer's own distro.
         cmd = ['git-buildpackage', '--git-dist=trusty', '--git-arch=amd64',
@@ -145,3 +147,24 @@ class RHCephPkg(object):
                '-us', '-uc']
         log.info(' '.join(cmd))
         subprocess.check_call(cmd)
+
+    def _get_j_arg(self, cpus, total_ram_gb=None):
+        """
+        Returns a string like "-j4" or "-j8". j is the number of processors,
+        with a maximum of x, where x = TOTAL_RAM_GB / 4.
+
+        We want to use all our processors (a high "j" value), but the build
+        process will fail with an "out of memory" error out if this j value is
+        too high.
+
+        An 8 GB system would have a maximum of -j2
+        A 16 GB system would have a maximum of -j4
+        A 32 GB system would have a maximum of -j8
+        """
+        if total_ram_gb is None:
+            page_size = os.sysconf('SC_PAGE_SIZE')
+            mem_bytes = page_size * os.sysconf('SC_PHYS_PAGES')
+            mem_gib = mem_bytes/(1024.**3)  # decimal, eg. 7.707 on 8GB system
+            # Round up to the nearest GB for our purposes.
+            total_ram_gb = math.ceil(mem_gib)
+        return '-j%d' % min(cpus, total_ram_gb / 4)

--- a/rhcephpkg/tests/test_main.py
+++ b/rhcephpkg/tests/test_main.py
@@ -46,6 +46,27 @@ class TestGetNumCpus(object):
         assert result == 4
 
 
+class TestGetJArg(object):
+    """ Test private _get_j_arg() function """
+
+    @pytest.mark.parametrize('cpus,ram,expected', [
+        (2, 8,  '-j2'),
+        (2, 16, '-j2'),
+        (2, 32, '-j2'),
+        (4, 8,  '-j2'),
+        (4, 16, '-j4'),
+        (4, 32, '-j4'),
+        (8, 8,  '-j2'),
+        (8, 16, '-j4'),
+        (8, 32, '-j8'),
+    ])
+    def test_get_j_arg(self, cpus, ram, expected, monkeypatch):
+        monkeypatch.setenv('HOME', FIXTURES_DIR)
+        rhcpkg = RHCephPkg()
+        result = rhcpkg._get_j_arg(cpus=cpus, total_ram_gb=ram)
+        assert result == expected
+
+
 class TestHelloJenkins(object):
 
     @classmethod


### PR DESCRIPTION
We want to use all our processors (a high "j" value), but the build process will fail with an "out of memory" error out if this j value is too high. Here's what I've found works through trial and error on some differently-sized build servers.