### PR TITLE
localbuild: handle systems with low RAM

### DIFF
--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -209,4 +209,5 @@ class RHCephPkg(object):
             mem_gib = mem_bytes/(1024.**3)  # decimal, eg. 7.707 on 8GB system
             # Round up to the nearest GB for our purposes.
             total_ram_gb = math.ceil(mem_gib)
-        return '-j%d' % min(cpus, total_ram_gb / 4)
+        number = min(cpus, total_ram_gb / 4)
+        return '-j%d' % max(number, 1)

--- a/rhcephpkg/tests/test_main.py
+++ b/rhcephpkg/tests/test_main.py
@@ -53,6 +53,7 @@ class TestGetJArg(object):
     """ Test private _get_j_arg() function """
 
     @pytest.mark.parametrize('cpus,ram,expected', [
+        (2, 2,  '-j1'),
         (2, 8,  '-j2'),
         (2, 16, '-j2'),
         (2, 32, '-j2'),


### PR DESCRIPTION
Prior to this change, if a system had less than 8GB RAM, `-j` would be "0". Set a lower bound so that `-j` is always at least "1".