### PR TITLE
use newer "gbp" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,5 +79,3 @@ TODO
   <https://pypi.python.org/pypi/tambo>`_
 * Add more commands, like ``rhcephpkg patch`` (equivalent of "rdopkg patch",
   and runs "gbp-pq export" under the hood)
-* Update for the newer git-buildpackage cli on Ubuntu Xenial (where everything
-  is a sub-command of ``gbp``.)

--- a/README.rst
+++ b/README.rst
@@ -78,4 +78,4 @@ TODO
 * Replace the hacky argparsing with `tambo
   <https://pypi.python.org/pypi/tambo>`_
 * Add more commands, like ``rhcephpkg patch`` (equivalent of "rdopkg patch",
-  and runs "gbp-pq export" under the hood)
+  and runs "gbp pq export" under the hood)

--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -175,7 +175,7 @@ class RHCephPkg(object):
         j_arg = self._get_j_arg(cpus)
         # FIXME: stop hardcoding trusty. Use the git branch name instead,
         # translating "-ubuntu" into this local computer's own distro.
-        cmd = ['git-buildpackage', '--git-dist=trusty', '--git-arch=amd64',
+        cmd = ['gbp', 'buildpackage', '--git-dist=trusty', '--git-arch=amd64',
                '--git-verbose', '--git-pbuilder', j_arg, '-us', '-uc']
         # TODO: we should also probably check parent dir for leftovers and warn
         # the user to delete them (or delete them ourselves?)
@@ -185,7 +185,7 @@ class RHCephPkg(object):
 
     def source(self):
         """ Build a source package on the local system. """
-        cmd = ['git-buildpackage', '--git-tag', '--git-retag', '-S',
+        cmd = ['gbp', 'buildpackage', '--git-tag', '--git-retag', '-S',
                '-us', '-uc']
         log.info(' '.join(cmd))
         subprocess.check_call(cmd)


### PR DESCRIPTION
Ubuntu Xenial ships git-buildpackage 0.7.2, which has removed the deprecated `/usr/bin/git-buildpackage` and `/usr/bin/gbp-pq` commands.