### PR TITLE
localbuild: fix pbuilder cache setup syntax

### DIFF
--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -178,7 +178,7 @@ class RHCephPkg(object):
         distro = 'trusty'
         pbuilder_cache = '/var/cache/pbuilder/base-%s-amd64.tgz' % distro
         if not os.path.isfile(pbuilder_cache):
-            cmd = ['sudo', 'pbuilder', 'create' '--debootstrapopts'
+            cmd = ['sudo', 'pbuilder', 'create', '--debootstrapopts',
                    '--variant=buildd', '--basetgz', pbuilder_cache,
                    '--distribution', distro]
             log.info('initializing pbuilder cache %s', pbuilder_cache)


### PR DESCRIPTION
Missed these commas in the previous commit.