### PR TITLE
patch: avoid whitespace in patches_sha1

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -37,7 +37,7 @@ Generate patches from a patch-queue branch.
 
         # Get the new sha1 to insert into the $COMMIT variable in d/rules
         cmd = ['git', 'rev-parse', patches_branch]
-        patches_sha1 = subprocess.check_output(cmd)
+        patches_sha1 = subprocess.check_output(cmd).rstrip()
 
         # Git-buildpackage pq operation
         cmd = ['gbp', 'pq', 'export']


### PR DESCRIPTION
Prior to this change, the `debian/rules` file would introduce a newline each time I ran "rhcephpkg patch". (Since we were't quoting the value in `debian/rules`, this ended up being harmless by coincidence.)

Trim the output of the sha1 discovery command so that the patches_sha1 string no longer contains a trailing newline.