### PR TITLE
.travis.yml: install pytest-flake8 in virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     # * 'python setup.py test' uses EasyInstall, so it will not upgrade a
     #   package to a newer version if the package is already present in a
     #   virtualenv.
-  - pip install --upgrade pytest>=2.8
+  - pip install pytest-flake8
   - pip install pytest-cov python-coveralls
 script:
   - python setup.py test -v -a "--cov-config .coveragerc --cov=rhcephpkg"


### PR DESCRIPTION
New builds in Travis are failing with this pytest-flake8 plugin, and I'm not sure of the root cause. Installing the package into the Travis virtualenv seems to fix it.