### PR TITLE
workaround python-jenkins-0.2.1's build_job()

### DIFF
--- a/rhcephpkg/build.py
+++ b/rhcephpkg/build.py
@@ -1,7 +1,18 @@
 from tambo import Transport
 import posixpath
+from pkg_resources import get_distribution, parse_version
+import types
 import rhcephpkg.log as log
 import rhcephpkg.util as util
+
+
+def _build_job_fixed(self, name, parameters, token):
+    """ Workaround for LP #1177831 """
+    # https://bugs.launchpad.net/python-jenkins/+bug/1177831
+    import urllib2  # NOQA
+    # Note the final empty string argument here:
+    return self.jenkins_open(urllib2.Request(
+        self.build_job_url(name, parameters, token), ''))
 
 
 class Build(object):
@@ -34,5 +45,16 @@ Build a package in Jenkins.
                  posixpath.join(jenkins.url, 'job', 'build-package'))
         job_params = {'PKG_NAME': pkg_name, 'BRANCH': branch_name}
 
+        if self._has_broken_build_job():
+            jenkins.build_job = types.MethodType(_build_job_fixed, jenkins)
+
         jenkins.build_job('build-package', parameters=job_params,
                           token=jenkins.password)
+
+    def _has_broken_build_job(self):
+        # Ubuntu Trusty ships python-jenkins 0.2.1-0ubuntu1, and this version
+        # has a broken build_job() method. See
+        # https://bugs.launchpad.net/python-jenkins/+bug/1177831 .
+        # This bug was fixed in python-jenkins v0.3.2 upstream.
+        v = get_distribution('python_jenkins').version
+        return parse_version(v) < parse_version('0.3.2')

--- a/rhcephpkg/tests/test_build.py
+++ b/rhcephpkg/tests/test_build.py
@@ -1,8 +1,14 @@
 import os
 from rhcephpkg import Build
+import pytest
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
+
+
+class FakeDistribution(object):
+    def __init__(self, version):
+        self.version = version
 
 
 class TestBuild(object):
@@ -30,3 +36,15 @@ class TestBuild(object):
         assert self.kwargs == {'parameters': {'BRANCH': 'ceph-2-ubuntu',
                                               'PKG_NAME': 'mypkg'},
                                'token': '5d41402abc4b2a76b9719d911017c592'}
+
+    @pytest.mark.parametrize('arg,expected', [
+        ('0.2.1', True),
+        ('0.3.3', False),
+    ])
+    def test_has_broken_build_job(self, arg, expected, monkeypatch):
+        monkeypatch.setenv('HOME', FIXTURES_DIR)
+        monkeypatch.setattr('rhcephpkg.build.get_distribution',
+                            lambda x: FakeDistribution(arg))
+        build = Build(())
+        result = build._has_broken_build_job()
+        assert result is expected

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     scripts=['bin/rhcephpkg'],
     install_requires=[
-        'python-jenkins',
+        'python-jenkins>=0.2.1',
         'six',
         'tambo>=0.1.0',
     ],


### PR DESCRIPTION
Prior to this change, the system version of Ubuntu Trusty's python-jenkins did not properly submit new jobs to Jenkins. The problem was that Jenkins expected a POST request, and python-jenkins-0.2.1 sent a GET request    instead.

To force python-jenkins to send a POST, copy upstream's solution (https://bugs.launchpad.net/python-jenkins/+bug/1177831) and pass an empty string to urllib2's Request constructor. The new `_has_broken_build_job()` method checks to see if we have a buggy python-jenkins version, and if not, we just fall through to the original behavior (without monkeypatching).

This commit could be reverted if we ever require a newer Ubuntu OS version (like Xenial) with a newer/less-buggy python-jenkins package.