### PR TITLE
localbuild: E226 missing whitespace around arithmetic operator

### DIFF
--- a/rhcephpkg/localbuild.py
+++ b/rhcephpkg/localbuild.py
@@ -78,7 +78,8 @@ Options:
         if total_ram_gb is None:
             page_size = os.sysconf('SC_PAGE_SIZE')
             mem_bytes = page_size * os.sysconf('SC_PHYS_PAGES')
-            mem_gib = mem_bytes/(1024.**3)  # decimal, eg. 7.707 on 8GB system
+            # mem_gib is a decimal, eg. 7.707 on 8GB system
+            mem_gib = mem_bytes / (1024. ** 3)
             # Round up to the nearest GB for our purposes.
             total_ram_gb = math.ceil(mem_gib)
         number = min(cpus, total_ram_gb / 4)

--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -18,7 +18,7 @@ class TestLocalbuild(object):
         return 0
 
     @pytest.mark.parametrize('args,expected', [
-        (('localbuild'),                     '--git-dist=trusty'),
+        (('localbuild'), '--git-dist=trusty'),
         (('localbuild', '--dist', 'trusty'), '--git-dist=trusty'),
         (('localbuild', '--dist', 'xenial'), '--git-dist=xenial'),
     ])
@@ -45,14 +45,14 @@ class TestGetJArg(object):
     """ Test private _get_j_arg() function """
 
     @pytest.mark.parametrize('cpus,ram,expected', [
-        (2, 2,  '-j1'),
-        (2, 8,  '-j2'),
+        (2, 2, '-j1'),
+        (2, 8, '-j2'),
         (2, 16, '-j2'),
         (2, 32, '-j2'),
-        (4, 8,  '-j2'),
+        (4, 8, '-j2'),
         (4, 16, '-j4'),
         (4, 32, '-j4'),
-        (8, 8,  '-j2'),
+        (8, 8, '-j2'),
         (8, 16, '-j4'),
         (8, 32, '-j8'),
     ])


### PR DESCRIPTION
Some version of flake8 complains about the whitespace here.