### PR TITLE
print help text when cmdline args are missing

### DIFF
--- a/rhcephpkg/clone.py
+++ b/rhcephpkg/clone.py
@@ -27,7 +27,7 @@ Positional Arguments:
         try:
             pkg = self.parser.unknown_commands[0]
         except IndexError:
-            self.help()
+            return self.parser.print_help()
         self._run(pkg)
 
     def help(self):

--- a/rhcephpkg/download.py
+++ b/rhcephpkg/download.py
@@ -32,7 +32,7 @@ Positional Arguments:
         try:
             build = self.parser.unknown_commands[0]
         except IndexError:
-            self.help()
+            return self.parser.print_help()
         self._run(build)
 
     def help(self):


### PR DESCRIPTION
Prior to this change, rhcephpkg would not print help messages when running `rhcephpkg clone` or `rhcephpkg download` without the required arguments.  Insetad, rhcephpkg would crash with ValueErrors, because help() does not exit the program, nor print to STDOUT.

Update the help calls in these cases so that we properly exit the program via return and print the help text to STDOUT.