### PR TITLE
download: handle mis-formatted build NVR

### DIFF
--- a/rhcephpkg/download.py
+++ b/rhcephpkg/download.py
@@ -45,7 +45,11 @@ Positional Arguments:
         except configparser.Error as err:
             raise SystemExit('Problem parsing .rhcephpkg.conf: %s',
                              err.message)
-        (pkg, version) = build.split('_')
+        try:
+            (pkg, version) = build.split('_')
+        except ValueError:
+            log.error('%s is not a valid package build N-V-R' % build)
+            return self.parser.print_help()
         build_url = posixpath.join(base_url, 'binaries/', pkg, version,
                                    'ubuntu', 'all')
         log.info('searching %s for builds' % build_url)


### PR DESCRIPTION
Prior to this change, if a user ommitted the package name in the argument to `rhcephpkg download`, then rhcephpkg would crash with an error, because it could not parse the build Name-Version-Release.

Crashes:

    rhcephpkg download 10.0.0-1

Correct:

    rhcephpkg download ceph_10.0.0-1

Catch the error and return a helpful message to the user in this case.