### PR TITLE
patch: handle starting from debian branch

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -32,9 +32,10 @@ Generate patches from a patch-queue branch.
     def _run(self):
         """ Generate quilt patch series with gbp pq, and update d/rules """
 
-        patches_branch = util.current_branch()
-        if not patches_branch.startswith('patch-queue/'):
-            raise SystemExit('%s is not a patch-queue branch' % patches_branch)
+        # Determine the names of the patch-queue branch and debian branch
+        current_branch = util.current_branch()
+        patches_branch = util.current_patches_branch()
+        debian_branch = util.current_debian_branch()
 
         # TODO: default to fetching from upstream, the way rdopkg patch does.
 
@@ -42,9 +43,10 @@ Generate patches from a patch-queue branch.
         cmd = ['git', 'rev-parse', patches_branch]
         patches_sha1 = subprocess.check_output(cmd).rstrip()
 
-        # Switch to "debian" branch
-        cmd = ['gbp', 'pq', 'switch']
-        subprocess.check_call(cmd)
+        # Switch to "debian" branch if necessary
+        if current_branch != debian_branch:
+            cmd = ['git', 'checkout', debian_branch]
+            subprocess.check_call(cmd)
 
         # Get the original (old) patch series
         old_series = self.read_series_file('debian/patches/series')

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from rhcephpkg import Patch
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -11,15 +10,6 @@ class FakePatch(object):
 
 
 class TestPatch(object):
-
-    def test_wrong_branch(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
-        monkeypatch.setattr('rhcephpkg.util.current_branch',
-                            lambda: 'ceph-2-ubuntu')
-        patch = Patch(())
-        with pytest.raises(SystemExit) as e:
-            patch._run()
-        assert str(e.value) == 'ceph-2-ubuntu is not a patch-queue branch'
 
     def test_get_rhbzs(self, monkeypatch):
         p = Patch(())

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -24,6 +24,17 @@ class TestUtilCurrentBranch(object):
         assert self.last_cmd == ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
         assert branch == 'fake-branch'
 
+    @pytest.mark.parametrize('current_branch', [
+        'ceph-2-ubuntu',
+        'patch-queue/ceph-2-ubuntu',
+    ])
+    def test_current_patches_and_debian_branches(self, monkeypatch,
+                                                 current_branch):
+        monkeypatch.setattr('rhcephpkg.util.current_branch',
+                            lambda: current_branch)
+        assert util.current_patches_branch() == 'patch-queue/ceph-2-ubuntu'
+        assert util.current_debian_branch() == 'ceph-2-ubuntu'
+
 
 class TestUtilConfig(object):
 

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -13,6 +13,24 @@ def current_branch():
     return subprocess.check_output(cmd).rstrip()
 
 
+def current_patches_branch():
+    """ Get our patch-queue branch's name, based on the current branch """
+    current = current_branch()
+    if current.startswith('patch-queue/'):
+        return current
+    else:
+        return 'patch-queue/' + current
+
+
+def current_debian_branch():
+    """ Get our debian branch's name, based on the current branch """
+    current = current_branch()
+    if current.startswith('patch-queue/'):
+        return current[12:]
+    else:
+        return current
+
+
 def config():
     """ Parse an rhcephpkg configuration file and return a ConfigParser object.
     """


### PR DESCRIPTION
Prior to this change, the user had to start `rhcephpkg patch` on a patch-queue branch, and rhcephpkg would bail with an error if the current branch was not a patch-queue branch.

With this change, rhcephpkg patch can handle starting on either the debian branch or the patch-queue branch. This makes the workflow a bit faster / more user-friendly.