### PR TITLE
add "merge-patches" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,9 @@ Commands
 
 * ``rhcephpkg localbuild`` - Perform a local build using pbuilder.
 
+* ``rhcephpkg merge-patches`` - Do a fast-forward merge from the rdopkg-style
+  "patches" remote branch.
+
 * ``rhcephpkg patch`` - Apply a patch-queue branch to a package.
 
 * ``rhcephpkg source`` - Build a source package on the local system.
@@ -83,11 +86,6 @@ TODO
 
 * ``rhcephpkg dch`` - Bump the changelog according to our "redhat" version
   number change pattern. This will help make rebases faster.
-
-* ``rhcephpkg merge-patches`` Do a fast-forward merge from the rdopkg-style
-  "patches" remote. For example to merge the ceph-2 patches branch:
-  ``git merge --ff-only patches/ceph-2-rhel-patches``. (This command would
-  need to automatically determine the name of the rdopkg patches branch.)
 
 * ``rhcephpkg amend`` - Amend the last Git commit to make the commit
   message align with the last ``debian/changelog`` entry. This would be similar

--- a/rhcephpkg/__init__.py
+++ b/rhcephpkg/__init__.py
@@ -4,10 +4,11 @@ from .clone import Clone
 from .download import Download
 from .hello import Hello
 from .localbuild import Localbuild
+from .merge_patches import MergePatches
 from .patch import Patch
 from .source import Source
 
 __all__ = ['log', 'Build', 'Clone', 'Download', 'Hello', 'Localbuild',
-           'Patch', 'Source']
+           'MergePatches', 'Patch', 'Source']
 
 __version__ = '1.1.8'

--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -23,6 +23,7 @@ Global Options:
         'download': rhcephpkg.Download,
         'hello': rhcephpkg.Hello,
         'localbuild': rhcephpkg.Localbuild,
+        'merge-patches': rhcephpkg.MergePatches,
         'patch': rhcephpkg.Patch,
         'source': rhcephpkg.Source,
     }

--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -1,0 +1,65 @@
+import re
+import subprocess
+from tambo import Transport
+import rhcephpkg.util as util
+import rhcephpkg.log as log
+
+
+class MergePatches(object):
+    help_menu = 'Merge patches from RHEL -patches branch to patch-queue branch'
+    _help = """
+Fetch the latest patches branch that rdopkg uses, and then fast-forward merge
+that into our local patch-queue branch, so that both branches align.
+
+"""
+    name = 'merge-patches'
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.options = []
+
+    def main(self):
+        self.parser = Transport(self.argv, options=self.options)
+        self.parser.catch_help = self.help()
+        self.parser.parse_args()
+        self._run()
+
+    def help(self):
+        return self._help
+
+    def _run(self):
+        # Determine the names of the relevant branches
+        current_branch = util.current_branch()
+        debian_branch = util.current_debian_branch()
+        patches_branch = util.current_patches_branch()
+        rhel_patches_branch = self.get_rhel_patches_branch(debian_branch)
+
+        # Do the merge
+        if current_branch == patches_branch:
+            # HEAD is our patch-queue branch. Use "git merge" directly.
+            # For example: "git merge -ff-only patches/ceph-2-rhel-patches"
+            cmd = ['git', 'merge', '--ff-only',
+                   'patches/' + rhel_patches_branch]
+        else:
+            # HEAD is our debian branch. Use "git fetch" to update the
+            # patch-queue ref. For example:
+            # "git fetch . \
+            #  patches/ceph-2-rhel-patches:patch-queue/ceph-2-ubuntu"
+            cmd = ['git', 'fetch', '.',
+                   'patches/%s:%s' % (rhel_patches_branch, patches_branch)]
+        log.info(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+    def get_rhel_patches_branch(self, debian_branch):
+        """
+        Get the RHEL -patches branch corresponding to this debian branch.
+
+        Examples:
+        ceph-2-ubuntu -> ceph-2-rhel-patches
+        ceph-2-trusty -> ceph-2-rhel-patches
+        ceph-2-xenial -> ceph-2-rhel-patches
+        ceph-1.3-ubuntu -> ceph-1.3-rhel-patches
+        """
+        deb_regex = r'^(\w+)-([\d\.]+)-.*'
+        rhel_regex = r'\1-\2-rhel-patches'
+        return re.sub(deb_regex, rhel_regex, debian_branch)

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+from rhcephpkg import MergePatches
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
+
+
+class TestMergePatches(object):
+
+    def setup_method(self, method):
+        """ Reset last_cmd before each test. """
+        self.last_cmd = None
+
+    def fake_check_call(self, cmd):
+        """ Store cmd, in order to verify it later. """
+        self.last_cmd = cmd
+        return 0
+
+    def test_merge_patch_on_debian_branch(self, monkeypatch):
+        monkeypatch.setenv('HOME', FIXTURES_DIR)
+        monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
+        # set current_branch() to a debian branch:
+        monkeypatch.setattr('rhcephpkg.util.current_branch',
+                            lambda: 'ceph-2-ubuntu')
+        localbuild = MergePatches(())
+        localbuild._run()
+        # Verify that we run the "git fetch" command here.
+        expected = ['git', 'fetch', '.',
+                    'patches/ceph-2-rhel-patches:patch-queue/ceph-2-ubuntu']
+        assert self.last_cmd == expected
+
+    def test_merge_patch_on_patch_queue_branch(self, monkeypatch):
+        monkeypatch.setenv('HOME', FIXTURES_DIR)
+        monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
+        # set current_branch() to a patch-queue branch:
+        monkeypatch.setattr('rhcephpkg.util.current_branch',
+                            lambda: 'patch-queue/ceph-2-ubuntu')
+        localbuild = MergePatches(())
+        localbuild._run()
+        # Verify that we run the "git merge" command here.
+        expected = ['git', 'merge', '--ff-only', 'patches/ceph-2-rhel-patches']
+        assert self.last_cmd == expected
+
+
+class TestMergePatchesRhelPatchesBranch(object):
+
+    @pytest.mark.parametrize('debian_branch,expected', [
+        ('ceph-1.3-ubuntu', 'ceph-1.3-rhel-patches'),
+        ('ceph-2-ubuntu', 'ceph-2-rhel-patches'),
+        ('ceph-2-trusty', 'ceph-2-rhel-patches'),
+        ('ceph-2-xenial', 'ceph-2-rhel-patches'),
+        ('someotherproduct-2-ubuntu', 'someotherproduct-2-rhel-patches'),
+    ])
+    def test_get_rhel_patches_branch(self, debian_branch, expected):
+        m = MergePatches(())
+        assert m.get_rhel_patches_branch(debian_branch) == expected


### PR DESCRIPTION
This command simplifies keeping our patch-queue branch up-to-date with what is in the rdopkg -patches branches for RPMs.