### PR TITLE
merge-patches: always fetch from the patches remote + other fixes

### DIFF
--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -11,6 +11,9 @@ class MergePatches(object):
 Fetch the latest patches branch that rdopkg uses, and then fast-forward merge
 that into our local patch-queue branch, so that both branches align.
 
+This command helps to align the patch series between our RHEL packages and our
+Ubuntu packages.
+
 """
     name = 'merge-patches'
 

--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -37,7 +37,8 @@ that into our local patch-queue branch, so that both branches align.
         # Do the merge
         if current_branch == patches_branch:
             # HEAD is our patch-queue branch. Use "git merge" directly.
-            # For example: "git merge -ff-only patches/ceph-2-rhel-patches"
+            # For example: "git merge --ff-only patches/ceph-2-rhel-patches"
+            subprocess.check_call(cmd)
             cmd = ['git', 'merge', '--ff-only',
                    'patches/' + rhel_patches_branch]
         else:

--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -36,10 +36,9 @@ that into our local patch-queue branch, so that both branches align.
 
         # Do the merge
         if current_branch == patches_branch:
-            # HEAD is our patch-queue branch. Use "git merge" directly.
-            # For example: "git merge --ff-only patches/ceph-2-rhel-patches"
-            subprocess.check_call(cmd)
-            cmd = ['git', 'merge', '--ff-only',
+            # HEAD is our patch-queue branch. Use "git pull" directly.
+            # For example: "git pull --ff-only patches/ceph-2-rhel-patches"
+            cmd = ['git', 'pull', '--ff-only',
                    'patches/' + rhel_patches_branch]
         else:
             # HEAD is our debian branch. Use "git fetch" to update the

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -39,7 +39,7 @@ class TestMergePatches(object):
         localbuild = MergePatches(())
         localbuild._run()
         # Verify that we run the "git merge" command here.
-        expected = ['git', 'merge', '--ff-only', 'patches/ceph-2-rhel-patches']
+        expected = ['git', 'pull', '--ff-only', 'patches/ceph-2-rhel-patches']
         assert self.last_cmd == expected
 
 


### PR DESCRIPTION
Prior to this change, `rhcephpkg merge-patches` would not always fetch the latest patches remote. If the user was currently on a patch-queue branch, rhcephpkg would run `git merge`, which does not fetch the remote.

If the user was on a debian branch instead, then `rhcephpkg merge-patches` would fetch the remote as expected.

Make both situations do the same fetch+merge operation, so it's easier to understand what this command does.