### PR TITLE
clone: add the "patches" remote for a package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Configuration
   user=kdreyer
   gitbaseurl = ssh://%(user)s@code.engineering.redhat.com/rcm/ceph-ubuntu/%(module)s
   anongiturl = git://git.app.eng.bos.redhat.com/rcm/ceph-ubuntu/%(module)s.git
+  patchesbaseurl = ssh://%(user)s@code.engineering.redhat.com/%(module)s
 
   [rhcephpkg.jenkins]
   token=5d41402abc4b2a76b9719d911017c592

--- a/rhcephpkg/clone.py
+++ b/rhcephpkg/clone.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 from six.moves import configparser
 from tambo import Transport
+import rhcephpkg.log as log
 import rhcephpkg.util as util
 
 
@@ -50,3 +51,12 @@ Positional Arguments:
         pkg_url = gitbaseurl % {'user': user, 'module': pkg}
         cmd = ['git', 'clone', pkg_url]
         subprocess.check_call(cmd)
+
+        try:
+            patchesbaseurl = configp.get('rhcephpkg', 'patchesbaseurl')
+            patches_url = patchesbaseurl % {'user': user, 'module': pkg}
+            os.chdir(pkg)
+            cmd = ['git', 'remote', 'add', '-f', 'patches', patches_url]
+            subprocess.check_call(cmd)
+        except configparser.Error as err:
+            log.info('no patchesbaseurl configured, skipping patches remote')


### PR DESCRIPTION
Almost all our Ubuntu packages have a corresponding "patches" remote
now.

Add the "patches" remote each time we clone a package.

TODO: tests