### PR TITLE
clone: fix error message when cloning existing dir

### DIFF
--- a/rhcephpkg/clone.py
+++ b/rhcephpkg/clone.py
@@ -37,8 +37,8 @@ Positional Arguments:
     def _run(self, pkg):
         """ Clone a package from dist-git. """
         if os.path.exists(pkg):
-            raise SystemExit('%s already exists in current working directory.',
-                             pkg)
+            err = '%s already exists in current working directory.' % pkg
+            raise SystemExit(err)
         configp = util.config()
         try:
             user = configp.get('rhcephpkg', 'user')

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -29,5 +29,7 @@ class TestClone(object):
         tmpdir.mkdir('mypkg')
         monkeypatch.chdir(tmpdir)
         clone = Clone(())
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as e:
             clone._run('mypkg')
+        expected = 'mypkg already exists in current working directory.'
+        assert str(e.value) == expected


### PR DESCRIPTION
Prior to this change, when cloning a package that has already been cloned (ie the directory already exists), rhcephpkg would exit with the following message:

```
$ rhcephpkg clone ceph
('%s already exists in current working directory.', 'ceph')
```

Interpolate the error string prior to passing to `SystemExit`.