### PR TITLE
merge-patches: fix --force branch ordering

### DIFF
--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -63,8 +63,8 @@ Options:
                    'patches/%s:%s' % (rhel_patches_branch, patches_branch)]
             if force:
                 # Do a hard push (with "+") instead.
-                cmd = ['git', 'push', '.', '+%s:patches/%s' %
-                       (patches_branch, rhel_patches_branch)]
+                cmd = ['git', 'push', '.', '+patches/%s:%s' %
+                       (rhel_patches_branch, patches_branch)]
         log.info(' '.join(cmd))
         subprocess.check_call(cmd)
 

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -52,7 +52,7 @@ class TestMergePatches(object):
         localbuild._run(force=True)
         # Verify that we run the "git push" command here.
         expected = ['git', 'push', '.',
-                    '+patch-queue/ceph-2-ubuntu:patches/ceph-2-rhel-patches']
+                    '+patches/ceph-2-rhel-patches:patch-queue/ceph-2-ubuntu']
         assert self.last_cmd == expected
 
     def test_force_on_patch_queue_branch(self, monkeypatch):


### PR DESCRIPTION
Prior to this change, when running rhcephpkg on the dist-git branch, `merge-patches --force` would merge in the wrong direction (Ubuntu -> RHEL rather than RHEL -> Ubuntu). Fix the ordering so `--force` does the right thing.