### PR TITLE
automatically setup pristine-tar branch

### DIFF
--- a/rhcephpkg/clone.py
+++ b/rhcephpkg/clone.py
@@ -60,3 +60,5 @@ Positional Arguments:
             subprocess.check_call(cmd)
         except configparser.Error as err:
             log.info('no patchesbaseurl configured, skipping patches remote')
+
+        util.setup_pristine_tar_branch()

--- a/rhcephpkg/localbuild.py
+++ b/rhcephpkg/localbuild.py
@@ -53,6 +53,9 @@ Options:
                    '--distribution', distro]
             log.info('initializing pbuilder cache %s', pbuilder_cache)
             subprocess.check_call(cmd)
+
+        util.setup_pristine_tar_branch()
+
         # TODO: we should also probably check parent dir for leftovers and warn
         # the user to delete them (or delete them ourselves?)
         cmd = ['gbp', 'buildpackage', '--git-dist=%s' % distro,

--- a/rhcephpkg/source.py
+++ b/rhcephpkg/source.py
@@ -1,6 +1,7 @@
 import subprocess
 from tambo import Transport
 import rhcephpkg.log as log
+import rhcephpkg.util as util
 
 
 class Source(object):
@@ -24,6 +25,7 @@ Build a source package on the local system.
 
     def _run(self):
         """ Build a source package on the local system. """
+        util.setup_pristine_tar_branch()
         cmd = ['gbp', 'buildpackage', '--git-tag', '--git-retag', '-S',
                '-us', '-uc']
         log.info(' '.join(cmd))

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -64,6 +64,18 @@ def package_name():
     return os.path.basename(os.getcwd())
 
 
+def setup_pristine_tar_branch():
+    """ Ensure .git/refs/heads/pristine-tar is set up. """
+    if not os.path.exists('.git/refs/remotes/origin/pristine-tar'):
+        # If there is no "origin/pristine-tar" branch, this package doesn't use
+        # pristine-tar, and we don't care.
+        return
+    if not os.path.exists('.git/refs/heads/pristine-tar'):
+        cmd = ['git', 'branch', '--track', 'pristine-tar',
+               'origin/pristine-tar']
+        subprocess.call(cmd)
+
+
 def get_user_fullname():
     """ Get a user's full name, if available. """
     # TODO: use $(git config --get user.name) instead


### PR DESCRIPTION
If the "origin" remote has a "pristine-tar" branch, set up a local tracking branch during during `clone`, `source`, `localbuild` operations.