### PR TITLE
clone: always chdir for final operations

### DIFF
--- a/rhcephpkg/clone.py
+++ b/rhcephpkg/clone.py
@@ -56,6 +56,8 @@ Positional Arguments:
         cmd = ['git', 'clone', pkg_url]
         subprocess.check_call(cmd)
 
+        os.chdir(pkg)
+
         try:
             patchesbaseurl = configp.get('rhcephpkg', 'patchesbaseurl')
         except configparser.Error as err:
@@ -65,7 +67,6 @@ Positional Arguments:
             cmd = ['git', 'ls-remote', '--exit-code', patches_url]
             result = subprocess.call(cmd, stdout=DEVNULL, stderr=DEVNULL)
             if result == 0:
-                os.chdir(pkg)
                 cmd = ['git', 'remote', 'add', '-f', 'patches', patches_url]
                 subprocess.check_call(cmd)
 

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -12,14 +12,25 @@ class TestClone(object):
         """ Reset last_cmd before each test. """
         self.last_cmd = None
 
+    def fake_git_clone(self, *args):
+        """ Just make a directory in cwd. """
+        try:
+            dirname = args[1]
+        except IndexError:
+            dirname = os.path.basename(args[0])
+        os.mkdir(dirname)
+
     def fake_check_call(self, cmd):
         """ Store cmd, in order to verify it later. """
+        if cmd[:2] == ['git', 'clone']:
+            self.fake_git_clone(*cmd[2:])
         self.last_cmd = cmd
         return 0
 
-    def test_basic_clone(self, monkeypatch):
+    def test_basic_clone(self, tmpdir, monkeypatch):
         monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
+        monkeypatch.chdir(tmpdir)
         clone = Clone(())
         clone._run('mypkg')
         assert self.last_cmd == ['git', 'clone',


### PR DESCRIPTION
Prior to this change, we would only chdir into the clone if there was as patches remote. If there was no patches remote, then we would not chdir, and the `util.setup_pristine_tar_branch()` call would be ineffective.

Always chdir after the clone so `util.setup_pristine_tar_branch()` can work.