### PR TITLE
patch: do nothing if there are no new patches

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -81,6 +81,9 @@ Generate patches from a patch-queue branch.
             if bzstr != '':
                 change += ' (%s)' % bzstr
             changelog.append(change)
+        if len(changelog) == 0:
+            print('No new patches, quitting.')
+            raise SystemExit(1)
         util.bump_changelog(changelog)
 
         # Assemble a standard commit message string "clog".


### PR DESCRIPTION
Prior to this change, rhcephpkg patch was not idempotent. If you run it
twice with the same patch-queue branch, it will bump the release in
/debian/changelog each time, even if there are no changelog entries to
add.

It is better to exit without touching any file or generating any
dist-git commit.

Exit with a non-zero exit code so that my internal auto-build scripts
will not try to kick off any new Jenkins build. This is kind of a hack,
but it's the quickest solution for now.