### PR TITLE
tests: fake HOME env var for all tests

### DIFF
--- a/rhcephpkg/tests/conftest.py
+++ b/rhcephpkg/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
+
+
+@pytest.fixture(autouse=True)
+def fake_home(monkeypatch):
+    monkeypatch.setenv('HOME', FIXTURES_DIR)

--- a/rhcephpkg/tests/test_build.py
+++ b/rhcephpkg/tests/test_build.py
@@ -1,9 +1,5 @@
-import os
 from rhcephpkg import Build
 import pytest
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class FakeDistribution(object):
@@ -25,7 +21,6 @@ class TestBuild(object):
         return 0
 
     def test_working_build(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('jenkins.Jenkins.build_job', self.fake_build_job)
         monkeypatch.setattr('rhcephpkg.util.package_name', lambda: 'mypkg')
         monkeypatch.setattr('rhcephpkg.util.current_branch',
@@ -42,7 +37,6 @@ class TestBuild(object):
         ('0.3.3', False),
     ])
     def test_has_broken_build_job(self, arg, expected, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('rhcephpkg.build.get_distribution',
                             lambda x: FakeDistribution(arg))
         build = Build(())

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -2,9 +2,6 @@ import os
 import pytest
 from rhcephpkg import Clone
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
-
 
 class TestClone(object):
 
@@ -28,7 +25,6 @@ class TestClone(object):
         return 0
 
     def test_basic_clone(self, tmpdir, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         monkeypatch.chdir(tmpdir)
         clone = Clone(())

--- a/rhcephpkg/tests/test_download.py
+++ b/rhcephpkg/tests/test_download.py
@@ -2,14 +2,10 @@ import os
 from rhcephpkg import Download
 from rhcephpkg.tests.util import fake_urlopen
 
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
-
 
 class TestDownload(object):
 
     def test_basic_download(self, monkeypatch, tmpdir):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('rhcephpkg.download.urlopen', fake_urlopen)
         monkeypatch.chdir(tmpdir)
         download = Download(())

--- a/rhcephpkg/tests/test_hello.py
+++ b/rhcephpkg/tests/test_hello.py
@@ -1,16 +1,10 @@
-import os
 from rhcephpkg import Hello
 from rhcephpkg.tests.util import fake_urlopen
-
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class TestHelloJenkins(object):
 
     def test_success(self, monkeypatch, capsys):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         # python-jenkins uses a "from" import, "from X import Y", so
         # monkeypatching is trickier.
         monkeypatch.setattr('jenkins.urlopen', fake_urlopen)

--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -1,9 +1,5 @@
-import os
 import pytest
 from rhcephpkg import Localbuild
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class TestLocalbuild(object):
@@ -23,7 +19,6 @@ class TestLocalbuild(object):
         (('localbuild', '--dist', 'xenial'), '--git-dist=xenial'),
     ])
     def test_localbuild(self, args, expected, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         monkeypatch.setattr('rhcephpkg.Localbuild._get_j_arg',
                             lambda *a: '-j2')
@@ -34,7 +29,6 @@ class TestLocalbuild(object):
                                  '--git-pbuilder', '-j2', '-us', '-uc']
 
     def test_missing_arg(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         localbuild = Localbuild(('localbuild', '--dist'))
         with pytest.raises(SystemExit) as e:
             localbuild.main()
@@ -57,7 +51,6 @@ class TestGetJArg(object):
         (8, 32, '-j8'),
     ])
     def test_get_j_arg(self, cpus, ram, expected, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         localbuild = Localbuild(())
         result = localbuild._get_j_arg(cpus=cpus, total_ram_gb=ram)
         assert result == expected

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -1,9 +1,5 @@
-import os
 import pytest
 from rhcephpkg import MergePatches
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class TestMergePatches(object):
@@ -18,7 +14,6 @@ class TestMergePatches(object):
         return 0
 
     def test_merge_patch_on_debian_branch(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         # set current_branch() to a debian branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
@@ -31,7 +26,6 @@ class TestMergePatches(object):
         assert self.last_cmd == expected
 
     def test_merge_patch_on_patch_queue_branch(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         # set current_branch() to a patch-queue branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
@@ -43,7 +37,6 @@ class TestMergePatches(object):
         assert self.last_cmd == expected
 
     def test_force_on_debian_branch(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         # set current_branch() to a debian branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
@@ -56,7 +49,6 @@ class TestMergePatches(object):
         assert self.last_cmd == expected
 
     def test_force_on_patch_queue_branch(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         # set current_branch() to a patch-queue branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -1,8 +1,4 @@
-import os
 from rhcephpkg import Patch
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class FakePatch(object):

--- a/rhcephpkg/tests/test_source.py
+++ b/rhcephpkg/tests/test_source.py
@@ -1,8 +1,4 @@
-import os
 from rhcephpkg import Source
-
-TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
-FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 
 class TestSource(object):
@@ -17,7 +13,6 @@ class TestSource(object):
         return 0
 
     def test_source(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         localbuild = Source(())
         localbuild._run()

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -46,7 +46,6 @@ class TestUtilConfig(object):
             c.get('some.section', 'someoption')
 
     def test_working_config_file(self, monkeypatch):
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         c = util.config()
         assert c.get('rhcephpkg', 'user') == 'kdreyer'
         assert c.get('rhcephpkg', 'gitbaseurl') == \
@@ -77,7 +76,6 @@ class TestUtilChangelog(object):
 
     def test_bump_changelog(self, tmpdir, monkeypatch):
         """ test bumping a debian changelog """
-        monkeypatch.setenv('HOME', FIXTURES_DIR)
         monkeypatch.chdir(tmpdir)
         # Our /debian/changelog fixture:
         source = py.path.local(FIXTURES_DIR).join('changelog')


### PR DESCRIPTION
Many tests were monkeypatching the `HOME` env var so we could read the `.rhcephpkg.conf` fixture file.

Centralize this code into `conftest.py` and reduce the copy-pasta.