### PR TITLE
.travis.yml: drop py33 and py34, add py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 # Add or remove version for match with Travis support
 python:
     - 2.7
-    - 3.3
-    - 3.4
     - 3.5
+    - 3.6
 install:
     # We have to upgrade pytest explicitly here due to the following:
     # * Travis CI's virtualenv already comes with pytest preinstalled.


### PR DESCRIPTION
Xenial ships Python 3.5, so let's keep that.