### PR TITLE
build on undefined args

### DIFF
--- a/rhcephpkg/localbuild.py
+++ b/rhcephpkg/localbuild.py
@@ -35,6 +35,11 @@ Options:
                 raise SystemExit('Specify a distro to --dist')
             distro = self.parser.get('--dist')
 
+        if self.parser.unknown_commands:
+            log.error('unknown option %s',
+                      ' '.join(self.parser.unknown_commands))
+            return self.parser.print_help()
+
         self._run(distro)
 
     def help(self):

--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -32,6 +32,10 @@ Options:
         force = False
         if self.parser.has(['--force', '--hard-reset']):
             force = True
+        if self.parser.unknown_commands:
+            log.error('unknown option %s',
+                      ' '.join(self.parser.unknown_commands))
+            return self.parser.print_help()
         self._run(force)
 
     def help(self):

--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -14,9 +14,9 @@ class TestLocalbuild(object):
         return 0
 
     @pytest.mark.parametrize('args,expected', [
-        (('localbuild'), '--git-dist=trusty'),
-        (('localbuild', '--dist', 'trusty'), '--git-dist=trusty'),
-        (('localbuild', '--dist', 'xenial'), '--git-dist=xenial'),
+        (['localbuild'], '--git-dist=trusty'),
+        (['localbuild', '--dist', 'trusty'], '--git-dist=trusty'),
+        (['localbuild', '--dist', 'xenial'], '--git-dist=xenial'),
     ])
     def test_localbuild(self, args, expected, monkeypatch):
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)


### PR DESCRIPTION
Make it clearer to the user when they've specified an unknown command-line option.