### PR TITLE
localbuild: delete zero-length cache file

### DIFF
--- a/rhcephpkg/localbuild.py
+++ b/rhcephpkg/localbuild.py
@@ -7,6 +7,16 @@ import rhcephpkg.log as log
 import rhcephpkg.util as util
 
 
+def setup_pbuilder_cache(pbuilder_cache, distro):
+    # Set up the cache if it does not exist.
+    if not os.path.isfile(pbuilder_cache):
+        log.info('initializing pbuilder cache %s', pbuilder_cache)
+        cmd = ['sudo', 'pbuilder', 'create', '--debootstrapopts',
+               '--variant=buildd', '--basetgz', pbuilder_cache,
+               '--distribution', distro]
+        subprocess.check_call(cmd)
+
+
 class Localbuild(object):
     help_menu = 'build a package on the local system'
     _help = """
@@ -52,12 +62,8 @@ Options:
         os.environ['BUILDER'] = 'pbuilder'
         j_arg = self._get_j_arg(cpu_count())
         pbuilder_cache = '/var/cache/pbuilder/base-%s-amd64.tgz' % distro
-        if not os.path.isfile(pbuilder_cache):
-            cmd = ['sudo', 'pbuilder', 'create', '--debootstrapopts',
-                   '--variant=buildd', '--basetgz', pbuilder_cache,
-                   '--distribution', distro]
-            log.info('initializing pbuilder cache %s', pbuilder_cache)
-            subprocess.check_call(cmd)
+
+        setup_pbuilder_cache(pbuilder_cache, distro)
 
         util.setup_pristine_tar_branch()
 

--- a/rhcephpkg/localbuild.py
+++ b/rhcephpkg/localbuild.py
@@ -8,6 +8,12 @@ import rhcephpkg.util as util
 
 
 def setup_pbuilder_cache(pbuilder_cache, distro):
+    # Delete existing cache file if it is bogus (zero-length).
+    if os.path.isfile(pbuilder_cache):
+        if os.stat(pbuilder_cache).st_size == 0:
+            log.info('deleting 0 length %s', pbuilder_cache)
+            cmd = ['sudo', 'rm', pbuilder_cache]
+            subprocess.check_call(cmd)
     # Set up the cache if it does not exist.
     if not os.path.isfile(pbuilder_cache):
         log.info('initializing pbuilder cache %s', pbuilder_cache)


### PR DESCRIPTION
If pbuilder crashed earlier or was interrupted (with ctrl-c), the pbuilder cache tarball might be zero-length. Subsequent `rhcephpkg localbuild` commands will fail.

`localbuild` should detect this condition (zero-length file) and delete the cache tarball entirely (like we do in Jenkins builds).