### PR TITLE
tests: drop unused pytest monkeypatch fixture

### DIFF
--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -30,7 +30,7 @@ class TestLocalbuild(object):
                                  '--git-arch=amd64', '--git-verbose',
                                  '--git-pbuilder', '-j2', '-us', '-uc']
 
-    def test_missing_arg(self, monkeypatch):
+    def test_missing_arg(self):
         localbuild = Localbuild(('localbuild', '--dist'))
         with pytest.raises(SystemExit) as e:
             localbuild.main()
@@ -52,7 +52,7 @@ class TestGetJArg(object):
         (8, 16, '-j4'),
         (8, 32, '-j8'),
     ])
-    def test_get_j_arg(self, cpus, ram, expected, monkeypatch):
+    def test_get_j_arg(self, cpus, ram, expected):
         localbuild = Localbuild(())
         result = localbuild._get_j_arg(cpus=cpus, total_ram_gb=ram)
         assert result == expected

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -45,7 +45,7 @@ class TestUtilConfig(object):
         with pytest.raises(Exception):
             c.get('some.section', 'someoption')
 
-    def test_working_config_file(self, monkeypatch):
+    def test_working_config_file(self):
         c = util.config()
         assert c.get('rhcephpkg', 'user') == 'kdreyer'
         assert c.get('rhcephpkg', 'gitbaseurl') == \
@@ -68,7 +68,7 @@ class TestUtilPackageName(object):
 
 class TestUtilChangelog(object):
 
-    def test_format_changelog(self, tmpdir, monkeypatch):
+    def test_format_changelog(self, tmpdir):
         """ test bumping a debian changelog """
         changes = ['a change', 'some other change', 'third change']
         expected = "  * a change\n  * some other change\n  * third change\n"
@@ -103,7 +103,7 @@ class TestUtilGetUserFullname(object):
         monkeypatch.setenv('NAME', 'Mr Plain Name')
         assert util.get_user_fullname() == 'Mr Plain Name'
 
-    def test_gecos(self, setup, monkeypatch):
+    def test_gecos(self, setup):
         assert util.get_user_fullname() == 'Mr Gecos'
 
 
@@ -118,7 +118,7 @@ class TestUtilSetupPristineTarBranch(object):
         self.last_cmd = cmd
         return 0
 
-    def test_no_remote_branch(self, tmpdir, monkeypatch):
+    def test_no_remote_branch(self, tmpdir):
         pkgdir = tmpdir.mkdir('mypkg')
         remotesdir = pkgdir.mkdir('.git').mkdir('refs').mkdir('remotes')
         remotesdir.mkdir('origin')


### PR DESCRIPTION
These monkeypatch fixtures are no longer used.  This was fallout from the HOME centralization in f05ac0e10288164dbeb597dcc828586fa9672e5e.