### PR TITLE
merge-patches: support branch suffixes

### DIFF
--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -1,4 +1,3 @@
-import re
 import subprocess
 from tambo import Transport
 import rhcephpkg.util as util
@@ -81,7 +80,13 @@ Options:
         ceph-2-trusty -> ceph-2-rhel-patches
         ceph-2-xenial -> ceph-2-rhel-patches
         ceph-1.3-ubuntu -> ceph-1.3-rhel-patches
+        ceph-2-ubuntu-hotfix-bz123 -> ceph-2-rhel-patches-hotfix-bz123
         """
-        deb_regex = r'^(\w+)-([\d\.]+)-.*'
-        rhel_regex = r'\1-\2-rhel-patches'
-        return re.sub(deb_regex, rhel_regex, debian_branch)
+        (product, version, distro) = debian_branch.split('-', 2)
+        suffix = None
+        if '-' in distro:
+            (distro, suffix) = distro.split('-', 1)
+        rhel = '%s-%s-rhel-patches' % (product, version)
+        if suffix is not None:
+            rhel = '%s-%s' % (rhel, suffix)
+        return rhel

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -68,6 +68,8 @@ class TestMergePatchesRhelPatchesBranch(object):
         ('ceph-2-trusty', 'ceph-2-rhel-patches'),
         ('ceph-2-xenial', 'ceph-2-rhel-patches'),
         ('someotherproduct-2-ubuntu', 'someotherproduct-2-rhel-patches'),
+        ('ceph-2-ubuntu-hotfix-bz123', 'ceph-2-rhel-patches-hotfix-bz123'),
+        ('ceph-2-ubuntu-test-bz456', 'ceph-2-rhel-patches-test-bz456'),
     ])
     def test_get_rhel_patches_branch(self, debian_branch, expected):
         m = MergePatches(())


### PR DESCRIPTION
Prior to this change, `get_rhel_patches_branch()` was translating a Debian dist-git branch `ceph-2-ubuntu-hotfix-bz123` to `ceph-2-rhel-patches`, stripping the suffix.

The result was that merge-patches cannot fetch changes from a RHEL -patches branch if it's a hotfix (or anything else special).

We need it to preserve the suffix in these cases, so merge-patches will work with hotfix branches.