### PR TITLE
setup.py: move import to top for flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import sys
 from setuptools.command.test import test as TestCommand
-from setuptools import Command
+from setuptools import setup, Command
 try:
     # Python 2 backwards compat
     from __builtin__ import raw_input as input
@@ -113,8 +113,6 @@ class PyTest(TestCommand):
         errno = pytest.main('rhcephpkg --flake8 ' + self.pytest_args)
         sys.exit(errno)
 
-
-from setuptools import setup
 
 setup(
     name='rhcephpkg',


### PR DESCRIPTION
Fixes flake8 error:
```
E402 module level import not at top of file
```