### PR TITLE
tests: pass empty lists to tambo

### DIFF
--- a/rhcephpkg/tests/test_build.py
+++ b/rhcephpkg/tests/test_build.py
@@ -25,7 +25,7 @@ class TestBuild(object):
         monkeypatch.setattr('rhcephpkg.util.package_name', lambda: 'mypkg')
         monkeypatch.setattr('rhcephpkg.util.current_branch',
                             lambda: 'ceph-2-ubuntu')
-        build = Build(())
+        build = Build([])
         build._run()
         assert self.args == ('build-package',)
         assert self.kwargs == {'parameters': {'BRANCH': 'ceph-2-ubuntu',

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -27,7 +27,7 @@ class TestClone(object):
     def test_basic_clone(self, tmpdir, monkeypatch):
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
         monkeypatch.chdir(tmpdir)
-        clone = Clone(())
+        clone = Clone([])
         clone._run('mypkg')
         assert self.last_cmd == ['git', 'clone',
                                  'ssh://kdreyer@git.example.com/ubuntu/mypkg']
@@ -35,7 +35,7 @@ class TestClone(object):
     def test_already_exists(self, tmpdir, monkeypatch):
         tmpdir.mkdir('mypkg')
         monkeypatch.chdir(tmpdir)
-        clone = Clone(())
+        clone = Clone([])
         with pytest.raises(SystemExit) as e:
             clone._run('mypkg')
         expected = 'mypkg already exists in current working directory.'

--- a/rhcephpkg/tests/test_download.py
+++ b/rhcephpkg/tests/test_download.py
@@ -8,7 +8,7 @@ class TestDownload(object):
     def test_basic_download(self, monkeypatch, tmpdir):
         monkeypatch.setattr('rhcephpkg.download.urlopen', fake_urlopen)
         monkeypatch.chdir(tmpdir)
-        download = Download(())
+        download = Download([])
         download._run('ceph_10.2.0-2redhat1trusty')
         expected = [
             'ceph_10.2.0-2redhat1trusty.debian.tar.gz',

--- a/rhcephpkg/tests/test_hello.py
+++ b/rhcephpkg/tests/test_hello.py
@@ -27,7 +27,7 @@ class TestHelloJenkins(object):
         # calls to urlopen(), not just jenkins' calls.
         # monkeypatch.setattr('six.moves.urllib.request.urlopen.func_code',
         #                     fake_urlopen.func_code)
-        hello = Hello(())
+        hello = Hello([])
         hello._run()
         out, _ = capsys.readouterr()
         assert out == "Hello Ken from Jenkins 1.5\n"

--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -54,7 +54,7 @@ class TestGetJArg(object):
         (8, 32, '-j8'),
     ])
     def test_get_j_arg(self, cpus, ram, expected):
-        localbuild = Localbuild(())
+        localbuild = Localbuild([])
         result = localbuild._get_j_arg(cpus=cpus, total_ram_gb=ram)
         assert result == expected
 

--- a/rhcephpkg/tests/test_merge_patches.py
+++ b/rhcephpkg/tests/test_merge_patches.py
@@ -18,7 +18,7 @@ class TestMergePatches(object):
         # set current_branch() to a debian branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
                             lambda: 'ceph-2-ubuntu')
-        localbuild = MergePatches(())
+        localbuild = MergePatches([])
         localbuild._run()
         # Verify that we run the "git fetch" command here.
         expected = ['git', 'fetch', '.',
@@ -30,7 +30,7 @@ class TestMergePatches(object):
         # set current_branch() to a patch-queue branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
                             lambda: 'patch-queue/ceph-2-ubuntu')
-        localbuild = MergePatches(())
+        localbuild = MergePatches([])
         localbuild._run()
         # Verify that we run the "git merge" command here.
         expected = ['git', 'pull', '--ff-only', 'patches/ceph-2-rhel-patches']
@@ -41,7 +41,7 @@ class TestMergePatches(object):
         # set current_branch() to a debian branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
                             lambda: 'ceph-2-ubuntu')
-        localbuild = MergePatches(())
+        localbuild = MergePatches([])
         localbuild._run(force=True)
         # Verify that we run the "git push" command here.
         expected = ['git', 'push', '.',
@@ -53,7 +53,7 @@ class TestMergePatches(object):
         # set current_branch() to a patch-queue branch:
         monkeypatch.setattr('rhcephpkg.util.current_branch',
                             lambda: 'patch-queue/ceph-2-ubuntu')
-        localbuild = MergePatches(())
+        localbuild = MergePatches([])
         localbuild._run(force=True)
         # Verify that we run the "git reset" command here.
         expected = ['git', 'reset', '--hard', 'patches/ceph-2-rhel-patches']
@@ -72,5 +72,5 @@ class TestMergePatchesRhelPatchesBranch(object):
         ('ceph-2-ubuntu-test-bz456', 'ceph-2-rhel-patches-test-bz456'),
     ])
     def test_get_rhel_patches_branch(self, debian_branch, expected):
-        m = MergePatches(())
+        m = MergePatches([])
         assert m.get_rhel_patches_branch(debian_branch) == expected

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -8,7 +8,7 @@ class FakePatch(object):
 class TestPatch(object):
 
     def test_get_rhbzs(self, monkeypatch):
-        p = Patch(())
+        p = Patch([])
         fakepatch = FakePatch()
         fakepatch.subject = 'my git change'
         fakepatch.long_desc = 'my long description about this change'

--- a/rhcephpkg/tests/test_source.py
+++ b/rhcephpkg/tests/test_source.py
@@ -14,7 +14,7 @@ class TestSource(object):
 
     def test_source(self, monkeypatch):
         monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
-        localbuild = Source(())
+        localbuild = Source([])
         localbuild._run()
         assert self.last_cmd == ['gbp', 'buildpackage', '--git-tag',
                                  '--git-retag', '-S', '-us', '-uc']


### PR DESCRIPTION
This tuple syntax is just too confusing. If we ever change this to a
one-element tuple like `('--help')`, Python evaluates that as a string,
unless I add the trailing comma `('--help',)`.

For consistency, let's just use lists everywhere. This more closely aligns with `sys.argv`'s type anyway.