### PR TITLE
travis: install ubuntu tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,7 @@ python:
     - 3.5
     - 3.6
 install:
-    # We have to upgrade pytest explicitly here due to the following:
-    # * Travis CI's virtualenv already comes with pytest preinstalled.
-    # * pytest-flake8 requires pytest>=2.8, and sometimes this requirement is
-    #   higher than what Travis CI has pre-installed into the virtualenv.
-    # * 'python setup.py test' uses EasyInstall, so it will not upgrade a
-    #   package to a newer version if the package is already present in a
-    #   virtualenv.
-  - pip install pytest-flake8
-  - pip install pytest-cov python-coveralls
-    # Install the git-buildpackage version from Ubuntu Trusty
-  - "[ ${TRAVIS_PYTHON_VERSION:0:1} == 2 ] && pip install -e git+https://github.com/agx/git-buildpackage@debian/0.6.9#egg=git-buildpackage-0.6.9 || :"
+  - ./travisci/install.sh
 script:
   - python setup.py test -v -a "--cov-config .coveragerc --cov=rhcephpkg"
 after_success:

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+  
+set -euv
+
+pip install pytest-flake8
+
+pip install pytest-cov python-coveralls
+
+if [ ${TRAVIS_PYTHON_VERSION:0:1} == 2 ]; then
+  pip install -e git+https://github.com/agx/git-buildpackage@debian/0.6.9#egg=git-buildpackage-0.6.9
+fi

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -7,5 +7,13 @@ pip install pytest-flake8
 pip install pytest-cov python-coveralls
 
 if [ ${TRAVIS_PYTHON_VERSION:0:1} == 2 ]; then
-  pip install -e git+https://github.com/agx/git-buildpackage@debian/0.6.9#egg=git-buildpackage-0.6.9
+  # Install the version from Trusty.
+  wget http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.6.9.tar.xz
+  tar xJf git-buildpackage_0.6.9.tar.xz
+  # It gets better. The tarball really wants to write to
+  # /etc/git-buildpackage/gpb.conf, which we cannot access without root.
+  pushd git-buildpackage-0.6.9
+    sed -i -e '/data_files/d' setup.py
+    python setup.py install
+  popd
 fi


### PR DESCRIPTION
The tag on GitHub points at a Git submodule that is no longer available.

Use the tarball from Ubuntu instead.