### PR TITLE
tests: add testpkg fixture and CallRecorder fixture

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import tempfile
+import six
 from tambo import Transport
 import rhcephpkg.util as util
 
@@ -40,7 +41,10 @@ Generate patches from a patch-queue branch.
 
         # Get the new sha1 to insert into the $COMMIT variable in d/rules
         cmd = ['git', 'rev-parse', patches_branch]
-        patches_sha1 = subprocess.check_output(cmd).rstrip()
+        output = subprocess.check_output(cmd)
+        patches_sha1 = output.rstrip()
+        if six.PY3:
+            patches_sha1 = output.decode('utf-8').rstrip()
 
         # Switch to "debian" branch if necessary
         if current_branch != debian_branch:

--- a/rhcephpkg/tests/conftest.py
+++ b/rhcephpkg/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+import py.path
+import subprocess
 
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -9,3 +11,24 @@ FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 @pytest.fixture(autouse=True)
 def fake_home(monkeypatch):
     monkeypatch.setenv('HOME', FIXTURES_DIR)
+
+
+@pytest.fixture
+def testpkg(tmpdir, monkeypatch):
+    """ Set up a minimal testpkg Git repository and chdir into it. """
+    fdir = py.path.local(FIXTURES_DIR)
+    dest = tmpdir.mkdir('testpkg')
+    fdir.join('testpkg').copy(dest)
+    monkeypatch.chdir(dest)
+    commands = [
+        ['git', 'init', '-q'],
+        ['git', 'config', 'user.name', 'Test User'],
+        ['git', 'config', 'user.email', 'test@example.com'],
+        ['git', 'add', '*'],
+        ['git', 'commit', '-q', '-m', 'initial import'],
+        ['git', 'branch', '-m', 'ceph-2-ubuntu'],
+        ['git', 'branch', 'patch-queue/ceph-2-ubuntu'],
+    ]
+    for c in commands:
+        subprocess.check_call(c)
+    return dest

--- a/rhcephpkg/tests/fixtures/testpkg/debian/changelog
+++ b/rhcephpkg/tests/fixtures/testpkg/debian/changelog
@@ -1,0 +1,5 @@
+testpkg (1.0.0-2redhat1) xenial; urgency=low
+
+  * Initial package
+
+ -- Ken Dreyer <kdreyer@redhat.com>  Tue, 06 Jun 2017 14:46:37 -0600

--- a/rhcephpkg/tests/fixtures/testpkg/debian/control
+++ b/rhcephpkg/tests/fixtures/testpkg/debian/control
@@ -1,0 +1,10 @@
+Source: testpkg
+Maintainer: Ken Dreyer <kdreyer@redhat.com>
+Section: python
+Priority: optional
+Standards-Version: 3.9.5
+
+Package: testpkg
+Architecture: all
+Depends: ${misc:Depends}
+Description: Dummy package for testing

--- a/rhcephpkg/tests/fixtures/testpkg/debian/gbp.conf
+++ b/rhcephpkg/tests/fixtures/testpkg/debian/gbp.conf
@@ -1,0 +1,10 @@
+[DEFAULT]
+debian-branch = ceph-2-ubuntu
+pristine-tar = False
+upstream-tag = v%(version)s
+
+[dch]
+# Use git committer as author
+git-author = True
+# Use a simple message format
+multimaint-merge = False

--- a/rhcephpkg/tests/fixtures/testpkg/debian/rules
+++ b/rhcephpkg/tests/fixtures/testpkg/debian/rules
@@ -1,0 +1,3 @@
+#!/usr/bin/make -f
+
+export COMMIT=b994c58959cb7b4485fcf4e40ff77c69e61a12cf

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -33,6 +33,7 @@ class TestClone(object):
         clone._run('mypkg')
         assert recorder.args == ['git', 'clone',
                                  'ssh://kdreyer@git.example.com/ubuntu/mypkg']
+        assert tmpdir.join('mypkg').check(dir=1)
 
     def test_already_exists(self, tmpdir, monkeypatch):
         tmpdir.mkdir('mypkg')

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -1,11 +1,74 @@
+import subprocess
 from rhcephpkg import Patch
+import pytest
+
+
+def git(*args):
+    """ shortcut for shelling out to git """
+    cmd = ['git'] + list(args)
+    return subprocess.check_output(cmd)
+
+
+class TestPatch(object):
+    @pytest.fixture
+    def testpkg(self, testpkg):
+        """
+        Override the testpkg fixture with some additional content.
+
+        TODO: just move this all to the main testpkg fixture? What's the
+        performance impact? (Note the checked-out branch behavior at the end is
+        different...)
+        """
+        # Add a "foobar" commit to the patch-queue branch.
+        git('checkout', 'patch-queue/ceph-2-ubuntu')
+        testpkg.join('foobar.py').ensure(file=True)
+        git('add', 'foobar.py')
+        git('commit', 'foobar.py', '-m', 'add foobar script',
+            '-m', 'Resolves: rhbz#123')
+        # Note we're not on the debian branch any more, so we implicitly test
+        # that path.
+        return testpkg
+
+    def test_series_file(self, testpkg):
+        """ Verify that we update the debian/patches/series file correctly. """
+        pytest.importorskip('gbp')
+        series_file = testpkg.join('debian').join('patches').join('series')
+        assert not series_file.exists()
+        p = Patch([])
+        p._run()
+        assert series_file.read() == "0001-add-foobar-script.patch\n"
+
+    def test_changelog(self, testpkg):
+        """ Verify that we update the debian/changelog file correctly. """
+        pytest.importorskip('gbp')
+        changelog_file = testpkg.join('debian').join('changelog')
+        p = Patch([])
+        p._run()
+        expected = """
+testpkg (1.0.0-3redhat1) stable; urgency=medium
+
+  * add foobar script (rhbz#123)
+
+""".lstrip("\n")
+        assert changelog_file.read().startswith(expected)
+
+    def test_rules(self, testpkg):
+        """ Verify that we update the debian/rules file correctly. """
+        pytest.importorskip('gbp')
+        rules_file = testpkg.join('debian').join('rules')
+        sha = git('rev-parse', 'patch-queue/ceph-2-ubuntu')
+        expected = 'COMMIT=%s' % sha
+        assert expected not in rules_file.read()
+        p = Patch([])
+        p._run()
+        assert expected in rules_file.read()
 
 
 class FakePatch(object):
     pass
 
 
-class TestPatch(object):
+class TestPatchGetRHBZs(object):
 
     def test_get_rhbzs(self):
         p = Patch([])
@@ -15,6 +78,3 @@ class TestPatch(object):
         bzs = p.get_rhbzs(fakepatch)
         assert len(bzs) == 0
         # TODO: more tests here, for commits that really contain RHBZs.
-
-    # TODO: more tests, faking check_call and check_output, to verify that
-    # we're running the proper gbp and git commands.

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -1,4 +1,5 @@
 import subprocess
+import six
 from rhcephpkg import Patch
 import pytest
 
@@ -6,7 +7,10 @@ import pytest
 def git(*args):
     """ shortcut for shelling out to git """
     cmd = ['git'] + list(args)
-    return subprocess.check_output(cmd)
+    output = subprocess.check_output(cmd)
+    if six.PY3:
+        return output.decode('utf-8').rstrip()
+    return output.rstrip()
 
 
 class TestPatch(object):

--- a/rhcephpkg/tests/test_source.py
+++ b/rhcephpkg/tests/test_source.py
@@ -1,20 +1,14 @@
 from rhcephpkg import Source
+from rhcephpkg.tests.util import CallRecorder
 
 
 class TestSource(object):
 
-    def setup_method(self, method):
-        """ Reset last_cmd before each test. """
-        self.last_cmd = None
-
-    def fake_check_call(self, cmd):
-        """ Store cmd, in order to verify it later. """
-        self.last_cmd = cmd
-        return 0
-
     def test_source(self, monkeypatch):
-        monkeypatch.setattr('subprocess.check_call', self.fake_check_call)
+        recorder = CallRecorder()
+        monkeypatch.setattr('subprocess.check_call', recorder)
         localbuild = Source([])
         localbuild._run()
-        assert self.last_cmd == ['gbp', 'buildpackage', '--git-tag',
-                                 '--git-retag', '-S', '-us', '-uc']
+        expected = ['gbp', 'buildpackage', '--git-tag', '--git-retag',
+                    '-S', '-us', '-uc']
+        assert recorder.args == expected

--- a/rhcephpkg/tests/util.py
+++ b/rhcephpkg/tests/util.py
@@ -16,10 +16,12 @@ class CallRecorder(object):
     def __init__(self):
         self.called = 0
 
-    def __call__(self, *a, **kw):
+    def __call__(self, *args, **kwargs):
         self.called += 1
-        self.a = a
-        self.kw = kw
+        try:
+            self.args = args[0]
+        except IndexError:
+            self.args = args
 
 
 def fake_urlopen(req, **kw):

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -3,6 +3,7 @@ import subprocess
 import pwd
 from textwrap import TextWrapper
 import time
+import six
 from six.moves import configparser
 from jenkins import Jenkins
 
@@ -10,7 +11,10 @@ from jenkins import Jenkins
 def current_branch():
     """ Get our current branch's name """
     cmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
-    return subprocess.check_output(cmd).rstrip()
+    output = subprocess.check_output(cmd).rstrip()
+    if six.PY3:
+        return output.decode('utf-8')
+    return output
 
 
 def current_patches_branch():

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -15,5 +15,7 @@ if [ ${TRAVIS_PYTHON_VERSION:0:1} == 2 ]; then
   pushd git-buildpackage-0.6.9
     sed -i -e '/data_files/d' setup.py
     python setup.py install
+    # gbp 0.6.9 depends on dateutil, but setuptools does not pull it in.
+    pip install python-dateutil
   popd
 fi


### PR DESCRIPTION
Run our tests in a "testpkg" Git clone. This allows us to stop monkeypatching so many subprocess invocations for Git and expand test coverage, particularly with test_patches.py. 

This uncovered a latent bug on py3 w.r.t subprocess.check_output's return type.