### PR TITLE
patch: enforce RHBZs in every patch

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -95,12 +95,12 @@ Generate patches from a patch-queue branch.
 
         # Get the new patch series
         new_series = self.read_series_file('debian/patches/series')
+        # Select only the ones that are new (according to commit subjects)
+        new_series = [p for p in new_series if p.subject not in old_subjects]
 
         # Add patch entries to d/changelog
         changelog = []
         for p in new_series:
-            if p.subject in old_subjects:
-                continue
             change = p.subject
             bzs = self.get_rhbzs(p)
             bzstr = ' '.join(map(lambda x: 'rhbz#%s' % x, bzs))

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -139,6 +139,11 @@ Generate patches from a patch-queue branch.
             # (.git_action attribute), include that in our log.
             try:
                 action = p.git_action
+                # Make common actions human-readable:
+                if action == 'M':
+                    action = 'Modified'
+                if action == 'D':
+                    action = 'Deleted'
                 change = '%s %s' % (action, p.path)
             except AttributeError:
                 # This was a simple patch addition, so just log the patch's

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -99,14 +99,7 @@ Generate patches from a patch-queue branch.
         new_series = [p for p in new_series if p.subject not in old_subjects]
 
         # Add patch entries to d/changelog
-        changelog = []
-        for p in new_series:
-            change = p.subject
-            bzs = self.get_rhbzs(p)
-            bzstr = ' '.join(map(lambda x: 'rhbz#%s' % x, bzs))
-            if bzstr != '':
-                change += ' (%s)' % bzstr
-            changelog.append(change)
+        changelog = self.generate_changelog(new_series)
         if len(changelog) == 0:
             # Maybe we rewrote some patch files? Write the raw git-status
             # output to the changelog so we have *something* to work with.
@@ -133,6 +126,22 @@ Generate patches from a patch-queue branch.
         # (This matches the behavior of "rdopkg patch".)
         cmd = ['git', '--no-pager', 'log', '--name-status', 'HEAD~..HEAD']
         subprocess.check_call(cmd)
+
+    def generate_changelog(self, series):
+        """
+        Generate a list of changelog entries for this Patch series.
+
+        :return: a list of strings
+        """
+        changelog = []
+        for p in series:
+            change = p.subject
+            bzs = self.get_rhbzs(p)
+            bzstr = ' '.join(map(lambda x: 'rhbz#%s' % x, bzs))
+            if bzstr != '':
+                change += ' (%s)' % bzstr
+            changelog.append(change)
+        return changelog
 
     def get_rhbzs(self, patch):
         bzs = re.findall(BZ_REGEX, patch.subject)

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -90,7 +90,7 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
         expected = """
 testpkg (1.0.0-4redhat1) stable; urgency=medium
 
-  * M  debian/patches/0001-add-foobar-script.patch
+  * M debian/patches/0001-add-foobar-script.patch (rhbz#123)
 
 """.lstrip("\n")
         result = changelog_file.read()

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -90,7 +90,7 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
         expected = """
 testpkg (1.0.0-4redhat1) stable; urgency=medium
 
-  * M debian/patches/0001-add-foobar-script.patch (rhbz#123)
+  * Modified debian/patches/0001-add-foobar-script.patch (rhbz#123)
 
 """.lstrip("\n")
         result = changelog_file.read()

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -39,7 +39,7 @@ class TestPatch(object):
         series_file = testpkg.join('debian').join('patches').join('series')
         assert not series_file.exists()
         p = Patch([])
-        p._run()
+        p.main()
         assert series_file.read() == "0001-add-foobar-script.patch\n"
 
     def test_changelog(self, testpkg):
@@ -47,7 +47,7 @@ class TestPatch(object):
         pytest.importorskip('gbp')
         changelog_file = testpkg.join('debian').join('changelog')
         p = Patch([])
-        p._run()
+        p.main()
         expected = """
 testpkg (1.0.0-3redhat1) stable; urgency=medium
 
@@ -64,27 +64,27 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
         expected = 'COMMIT=%s' % sha
         assert expected not in rules_file.read()
         p = Patch([])
-        p._run()
+        p.main()
         assert expected in rules_file.read()
 
     def test_no_changes(self, testpkg, capsys):
         """ Verify that we bail when no patches have changed. """
         pytest.importorskip('gbp')
         p = Patch([])
-        p._run()
+        p.main()
         with pytest.raises(SystemExit):
-            p._run()
+            p.main()
         out, _ = capsys.readouterr()
         assert 'No new patches, quitting.' in out
 
     def test_amended_patch(self, testpkg, capsys):
         pytest.importorskip('gbp')
         p = Patch([])
-        p._run()
+        p.main()
         git('checkout', 'patch-queue/ceph-2-ubuntu')
         testpkg.join('foobar.py').write('#!/usr/bin/python')
         git('commit', 'foobar.py', '--amend', '--reset-author', '--no-edit')
-        p._run()
+        p.main()
         changelog_file = testpkg.join('debian').join('changelog')
         expected = """
 testpkg (1.0.0-4redhat1) stable; urgency=medium

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -54,7 +54,8 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
   * add foobar script (rhbz#123)
 
 """.lstrip("\n")
-        assert changelog_file.read().startswith(expected)
+        result = changelog_file.read()
+        assert result.startswith(expected)
 
     def test_rules(self, testpkg):
         """ Verify that we update the debian/rules file correctly. """
@@ -92,7 +93,8 @@ testpkg (1.0.0-4redhat1) stable; urgency=medium
   * M  debian/patches/0001-add-foobar-script.patch
 
 """.lstrip("\n")
-        assert changelog_file.read().startswith(expected)
+        result = changelog_file.read()
+        assert result.startswith(expected)
 
 
 class FakePatch(object):


### PR DESCRIPTION
To support running unattended in Jenkins, `rhcephpkg patch` now validates that each new patch contains an RHBZ number. If a patch lacks RHBZ numbers, the patch operation fails. Users can optionally override this guard with the `--nobz` CLI option.