### PR TITLE
make git-buildpackage mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
 sudo: false
-# Add or remove version for match with Travis support
-python:
-    - 2.7
-    - 3.5
-    - 3.6
+matrix:
+  # Add or remove versions to match what Travis supports
+  include:
+    - python: '2.7'
+      env: GIT_BUILDPACKAGE_SOURCE=trusty
+    - python: '2.7'
+      env: GIT_BUILDPACKAGE_SOURCE=xenial
+    - python: '3.5'
+      env: GIT_BUILDPACKAGE_SOURCE=master
+    - python: '3.6'
+      env: GIT_BUILDPACKAGE_SOURCE=master
 install:
   - ./travisci/install.sh
 script:

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -143,7 +143,7 @@ Options:
         clog += util.format_changelog(changelog)
 
         # Commit everything with the standard commit message.
-        with tempfile.NamedTemporaryFile() as temp:
+        with tempfile.NamedTemporaryFile(mode='w+') as temp:
             temp.write(clog)
             temp.flush()
             cmd = ['git', 'commit', 'debian/changelog', 'debian/patches',

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -3,6 +3,7 @@ import subprocess
 import tempfile
 import six
 from tambo import Transport
+import gbp.patch_series
 import rhcephpkg.util as util
 
 BZ_REGEX = r'rhbz#(\d+)'
@@ -189,13 +190,7 @@ Options:
         return bzs
 
     def read_series_file(self, file_):
-        try:
-            import gbp.patch_series
-            return gbp.patch_series.PatchSeries.read_series_file(file_)
-        except ImportError:
-            raise SystemExit(
-                'Please run "sudo apt-get install git-buildpackage" to write '
-                'the patches to ./debian/changelog')
+        return gbp.patch_series.PatchSeries.read_series_file(file_)
 
     def read_git_debian_patches(self):
         """
@@ -206,11 +201,6 @@ Options:
 
         :return: a list of gbp.patch_series.Patch objects
         """
-        try:
-            import gbp.patch_series
-        except ImportError:
-            raise SystemExit(
-                'Please run "sudo apt-get install git-buildpackage"')
         cmd = ['git', 'status', '-s', 'debian/patches/']
         output = subprocess.check_output(cmd)
         if six.PY3:

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -35,7 +35,6 @@ class TestPatch(object):
 
     def test_series_file(self, testpkg):
         """ Verify that we update the debian/patches/series file correctly. """
-        pytest.importorskip('gbp')
         series_file = testpkg.join('debian').join('patches').join('series')
         assert not series_file.exists()
         p = Patch([])
@@ -44,7 +43,6 @@ class TestPatch(object):
 
     def test_changelog(self, testpkg):
         """ Verify that we update the debian/changelog file correctly. """
-        pytest.importorskip('gbp')
         changelog_file = testpkg.join('debian').join('changelog')
         p = Patch([])
         p.main()
@@ -59,7 +57,6 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
 
     def test_rules(self, testpkg):
         """ Verify that we update the debian/rules file correctly. """
-        pytest.importorskip('gbp')
         rules_file = testpkg.join('debian').join('rules')
         sha = git('rev-parse', 'patch-queue/ceph-2-ubuntu')
         expected = 'COMMIT=%s' % sha
@@ -70,7 +67,6 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
 
     def test_no_changes(self, testpkg, capsys):
         """ Verify that we bail when no patches have changed. """
-        pytest.importorskip('gbp')
         p = Patch([])
         p.main()
         with pytest.raises(SystemExit):
@@ -79,7 +75,6 @@ testpkg (1.0.0-3redhat1) stable; urgency=medium
         assert 'No new patches, quitting.' in out
 
     def test_amended_patch(self, testpkg, capsys):
-        pytest.importorskip('gbp')
         p = Patch([])
         p.main()
         git('checkout', 'patch-queue/ceph-2-ubuntu')

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     scripts=['bin/rhcephpkg'],
     install_requires=[
+        'gbp',
         'python-jenkins>=0.2.1',
         'six',
         'tambo>=0.1.0',

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -6,17 +6,37 @@ pip install pytest-flake8
 
 pip install pytest-cov python-coveralls
 
-if [ ${TRAVIS_PYTHON_VERSION:0:1} == 2 ]; then
-  # Install the version from Trusty.
-  wget http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.6.9.tar.xz
-  tar xJf git-buildpackage_0.6.9.tar.xz
-  # It gets better. The tarball really wants to write to
-  # /etc/git-buildpackage/gpb.conf, which we cannot access without root.
-  pushd git-buildpackage-0.6.9
-    sed -i -e '/data_files/d' setup.py
-    python setup.py install
-    # gbp depends on dateutil, but setuptools does not pull it in.
-    # This packaging bug is fixed in git-buildpackage version 0.8.18.
-    pip install python-dateutil
-  popd
+# Install the version from GitHub master by default.
+# Note: 0.9 is the first gbp version to include full py3 support.
+# Things like `gbp pq export` are broken on py3 before this version.
+# This is why I'm testing master on py3 for now.
+GIT_BUILDPACKAGE_SOURCE=${GIT_BUILDPACKAGE_SOURCE:-master}
+
+declare -A GBP_SOURCES
+GBP_SOURCES[trusty]=http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.6.9.tar.xz
+GBP_SOURCES[xenial]=http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.7.2.tar.xz
+GBP_SOURCES[master]=https://github.com/agx/git-buildpackage/archive/master/git-buildpackage-master.tar.gz
+
+# Install the desired version.
+
+GBP_URL=${GBP_SOURCES[$GIT_BUILDPACKAGE_SOURCE]}
+GBP_FILE=$(basename ${GBP_URL})
+GBP_DIR=$(echo $GBP_FILE | sed -e "s/.tar.[gx]z$//" -e "s/_/-/")
+
+wget -nc $GBP_URL
+
+if [[ "$GBP_FILE" == *.xz ]]; then
+  tar xJf ${GBP_FILE}
+elif [[ "$GBP_FILE" == *.gz ]]; then
+  tar xzf ${GBP_FILE}
 fi
+
+pushd $GBP_DIR
+  # In old versions, the setuptools packaging really wants to write to
+  # /etc/git-buildpackage/gpb.conf, which we cannot access without root.
+  sed -i -e '/data_files/d' setup.py
+  python setup.py install
+  # gbp depends on dateutil, but setuptools does not pull it in.
+  # This packaging bug is fixed in git-buildpackage version 0.8.18.
+  pip install python-dateutil
+popd


### PR DESCRIPTION
Install gbp on both py2 and py3 in Travis CI.

Drop the crufty code where we conditionally import gbp, and just make it mandatory.

This allows us to run more patch tests on py3 in Travis CI. Two follow-up commits fix some py3-related type errors that the tests uncovered due to this change.