### PR TITLE
clone: handle python package names

### DIFF
--- a/rhcephpkg/tests/fixtures/.rhcephpkg.conf
+++ b/rhcephpkg/tests/fixtures/.rhcephpkg.conf
@@ -2,6 +2,7 @@
 user=kdreyer
 gitbaseurl = ssh://%(user)s@git.example.com/ubuntu/%(module)s
 anongiturl = git://git.example.com/ubuntu/%(module)s
+patchesbaseurl = git://git.example.com/%(module)s
 
 [rhcephpkg.jenkins]
 token=5d41402abc4b2a76b9719d911017c592

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -25,6 +25,14 @@ class CheckCallRecorder(CallRecorder):
 
 class TestClone(object):
 
+    def test_no_args(self, capsys):
+        clone = Clone(['rhcephpkg'])
+        with pytest.raises(SystemExit):
+            clone.main()
+        out, _ = capsys.readouterr()
+        expected = clone._help + "\n"
+        assert out == expected
+
     def test_basic_clone(self, tmpdir, monkeypatch):
         recorder = CheckCallRecorder()
         monkeypatch.setattr('subprocess.check_call', recorder)

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -51,3 +51,13 @@ class TestClone(object):
             clone.main()
         expected = 'mypkg already exists in current working directory.'
         assert str(e.value) == expected
+
+    def test_python_package(self, tmpdir, monkeypatch):
+        recorder = CheckCallRecorder()
+        monkeypatch.setattr('subprocess.check_call', recorder)
+        monkeypatch.chdir(tmpdir)
+        clone = Clone(['rhcephpkg', 'python-apipkg'])
+        clone.main()
+        assert recorder.args == ['git', 'clone',
+                                 'ssh://kdreyer@git.example.com/ubuntu/apipkg']
+        assert tmpdir.join('apipkg').check(dir=1)

--- a/rhcephpkg/tests/test_clone.py
+++ b/rhcephpkg/tests/test_clone.py
@@ -37,8 +37,8 @@ class TestClone(object):
         recorder = CheckCallRecorder()
         monkeypatch.setattr('subprocess.check_call', recorder)
         monkeypatch.chdir(tmpdir)
-        clone = Clone([])
-        clone._run('mypkg')
+        clone = Clone(['rhcephpkg', 'mypkg'])
+        clone.main()
         assert recorder.args == ['git', 'clone',
                                  'ssh://kdreyer@git.example.com/ubuntu/mypkg']
         assert tmpdir.join('mypkg').check(dir=1)
@@ -46,8 +46,8 @@ class TestClone(object):
     def test_already_exists(self, tmpdir, monkeypatch):
         tmpdir.mkdir('mypkg')
         monkeypatch.chdir(tmpdir)
-        clone = Clone([])
+        clone = Clone(['rhcephpkg', 'mypkg'])
         with pytest.raises(SystemExit) as e:
-            clone._run('mypkg')
+            clone.main()
         expected = 'mypkg already exists in current working directory.'
         assert str(e.value) == expected


### PR DESCRIPTION
Our python packages are named differently on RHEL vs Ubuntu.

If running "clone" with a python-* package name, switch to the Debian bare package name instead.

This allows us to run "rhcephpkg clone python-foo" in Jenkins (triggered if we see "python-foo"'s patches branch change.)