### PR TITLE
log: set INFO on rhcephpkg logger only

### DIFF
--- a/rhcephpkg/gitbz.py
+++ b/rhcephpkg/gitbz.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import subprocess
 import six
@@ -12,7 +11,6 @@ BZ_REGEX = r'rhbz#(\d+)'
 
 def get_bzapi():
     """ Return a logged-in RHBZ API instance """
-    logging.getLogger('bugzilla').setLevel(logging.WARNING)
     bzapi = Bugzilla('bugzilla.redhat.com')
     if not bzapi.logged_in:
         raise SystemExit('Not logged into BZ')

--- a/rhcephpkg/log.py
+++ b/rhcephpkg/log.py
@@ -1,4 +1,5 @@
 import logging
 
-logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+logging.basicConfig(format='%(levelname)s: %(message)s')
 log = logging.getLogger('rhcephpkg')
+log.setLevel(logging.INFO)


### PR DESCRIPTION
Also, remove logging adjustment from gitbz. Now that we're only setting INFO level on the rhcephpkg logger, we don't need to touch the bugzilla logger.