### PR TITLE
add "checkout-from-patches" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,10 @@ Commands
 
 * ``rhcephpkg build`` - Trigger a build in Jenkins.
 
+* ``rhcephpkg checkout-from-patches`` - Choose a Debian branch based on a RHEL
+  `rdopkg <https://github.com/softwarefactory-project/rdopkg>`_-style
+  "patches" branch.
+
 * ``rhcephpkg download`` - Download a build's artifacts from chacra.
 
 * ``rhcephpkg hello`` - Test Jenkins authentication. Use this to verify your

--- a/rhcephpkg/__init__.py
+++ b/rhcephpkg/__init__.py
@@ -1,5 +1,6 @@
 from .log import log
 from .build import Build
+from .checkout_from_patches import CheckoutFromPatches
 from .clone import Clone
 from .download import Download
 from .gitbz import Gitbz
@@ -9,7 +10,7 @@ from .merge_patches import MergePatches
 from .patch import Patch
 from .source import Source
 
-__all__ = ['log', 'Build', 'Clone', 'Download', 'Gitbz', 'Hello', 'Localbuild',
-           'MergePatches', 'Patch', 'Source']
+__all__ = ['log', 'Build', 'CheckoutFromPatches', 'Clone', 'Download',
+           'Gitbz', 'Hello', 'Localbuild', 'MergePatches', 'Patch', 'Source']
 
 __version__ = '1.4.0'

--- a/rhcephpkg/checkout_from_patches.py
+++ b/rhcephpkg/checkout_from_patches.py
@@ -1,0 +1,81 @@
+import os
+import re
+import subprocess
+from tambo import Transport
+import rhcephpkg.log as log
+
+
+class CheckoutFromPatches(object):
+    help_menu = 'Choose a Debian branch based on a RHEL -patches branch'
+    _help = """
+Check out the Git branch that corresponds to a given RHEL (rdopkg-style)
+-patches branch.
+
+If you are starting from a RHEL -patches branch name (say, from a trigger in
+Jenkins), this will automatically choose the right Debian branch that goes
+with your -patches branch.
+
+Example:
+
+  rhcephpkg checkout-from-patches ceph-3.0-rhel-patches
+
+... this will checkout the "ceph-3.0-xenial" Git branch if it exists in the
+"origin" remote, or fall back to the "ceph-3.0-ubuntu" branch, or error if
+neither exist.
+
+Positional Arguments:
+
+[branch]  The name of the -patches branch.
+"""
+    name = 'checkout-from-patches'
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.options = []
+
+    def main(self):
+        self.parser = Transport(self.argv, options=self.options)
+        self.parser.catch_help = self.help()
+        self.parser.parse_args()
+        try:
+            patches_branch = self.parser.unknown_commands[0]
+        except IndexError:
+            return self.parser.print_help()
+        self._run(patches_branch)
+
+    def help(self):
+        return self._help
+
+    def _run(self, patches_branch):
+        debian_branch = self.get_debian_branch(patches_branch)
+        if not debian_branch:
+            err = 'could not find debian branch for %s' % patches_branch
+            raise SystemExit(err)
+
+        cmd = ['git', 'checkout', debian_branch]
+        log.info(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+    def get_debian_branch(self, patches_branch):
+        """
+        Get the debian branch corresponding to this RHEL -patches branch.
+
+        Examples:
+        ceph-2-rhel-patches -> ceph-2-xenial or ceph-2-ubuntu
+        ceph-2-rhel-patches-hotfix-bz123 -> ceph-2-ubuntu-hotfix-bz123
+
+        :returns: name of debian branch, or None if none was found.
+        """
+        patches_re = re.compile('-rhel-patches')
+        debian_re = patches_re.sub('-([a-z]+)', patches_branch)
+        branches = os.listdir('.git/refs/remotes/origin/')
+        ubuntu_branch = None
+        for branch in branches:
+            m = re.search(debian_re, branch)
+            if m:
+                if m.group(1) == 'ubuntu':
+                    # Use this only if we could find no other distro branch.
+                    ubuntu_branch = branch
+                else:
+                    return branch
+        return ubuntu_branch

--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -19,6 +19,7 @@ Global Options:
 
     mapper = {
         'build': rhcephpkg.Build,
+        'checkout-from-patches': rhcephpkg.CheckoutFromPatches,
         'clone': rhcephpkg.Clone,
         'download': rhcephpkg.Download,
         'gitbz': rhcephpkg.Gitbz,

--- a/rhcephpkg/tests/test_checkout_from_patches.py
+++ b/rhcephpkg/tests/test_checkout_from_patches.py
@@ -1,0 +1,65 @@
+import os
+import pytest
+from rhcephpkg.checkout_from_patches import CheckoutFromPatches
+from rhcephpkg.tests.util import CallRecorder
+
+
+class TestCheckoutFromPatches(object):
+
+    @pytest.fixture(autouse=True)
+    def fake_clone(self, tmpdir, monkeypatch):
+        """ Fake just enough of a git clone. """
+        origin = tmpdir.join('.git/refs/remotes/origin')
+        branches = ['ceph-2-xenial',
+                    'ceph-3.0-ubuntu',
+                    'ceph-2-ubuntu-hotfix-bz123',
+                    'private-kdreyer-ceph-2-ubuntu-test-bz456']
+        os.makedirs(str(origin))
+        for branch in branches:
+            origin.mkdir(branch)
+        monkeypatch.chdir(tmpdir)
+
+    @pytest.mark.parametrize('patches_branch,expected', [
+        ('ceph-2-rhel-patches', 'ceph-2-xenial'),
+        ('ceph-3.0-rhel-patches', 'ceph-3.0-ubuntu'),
+        ('ceph-2-rhel-patches-hotfix-bz123', 'ceph-2-ubuntu-hotfix-bz123'),
+        ('private-kdreyer-ceph-2-rhel-patches-test-bz456',
+         'private-kdreyer-ceph-2-ubuntu-test-bz456'),
+        ('ceph-4.0-rhel-patches', None),
+    ])
+    def test_get_debian_branch(self, patches_branch, expected):
+        cfp = CheckoutFromPatches(['checkout-from-patches', patches_branch])
+        result = cfp.get_debian_branch(patches_branch)
+        assert result == expected
+
+    def test_no_args(self, capsys):
+        cfp = CheckoutFromPatches(['checkout-from-patches'])
+        with pytest.raises(SystemExit):
+            cfp.main()
+        out, _ = capsys.readouterr()
+        assert cfp._help in out
+
+    def test_help(self, capsys):
+        cfp = CheckoutFromPatches(['checkout-from-patches', '--help'])
+        with pytest.raises(SystemExit):
+            cfp.main()
+        out, _ = capsys.readouterr()
+        assert cfp._help in out
+
+    def test_checkout(self, tmpdir, monkeypatch):
+        """ Test the happy path for checking out a branch """
+        recorder = CallRecorder()
+        monkeypatch.setattr('subprocess.check_call', recorder)
+        argv = ['checkout-from-patches', 'ceph-2-rhel-patches']
+        cfp = CheckoutFromPatches(argv)
+        cfp.main()
+        assert recorder.args == ['git', 'checkout', 'ceph-2-xenial']
+
+    def test_bad_checkout(self):
+        """ Test a branch that doesn't exist """
+        argv = ['checkout-from-patches', 'ceph-4.0-rhel-patches']
+        cfp = CheckoutFromPatches(argv)
+        with pytest.raises(SystemExit) as e:
+            cfp.main()
+        expected = 'could not find debian branch for ceph-4.0-rhel-patches'
+        assert str(e.value) == expected


### PR DESCRIPTION
Check out the Git branch that corresponds to a given RHEL (rdopkg-style) -patches branch.

This will make it easier to automatically apply new patches within Jenkins.