### PR TITLE
checkout-from-patches: list remote branches with git

### DIFF
--- a/rhcephpkg/checkout_from_patches.py
+++ b/rhcephpkg/checkout_from_patches.py
@@ -1,6 +1,6 @@
-import os
 import re
 import subprocess
+import six
 from tambo import Transport
 import rhcephpkg.log as log
 
@@ -68,9 +68,8 @@ Positional Arguments:
         """
         patches_re = re.compile('-rhel-patches')
         debian_re = patches_re.sub('-([a-z]+)', patches_branch)
-        branches = os.listdir('.git/refs/remotes/origin/')
         ubuntu_branch = None
-        for branch in branches:
+        for branch in self.get_origin_branches():
             m = re.search(debian_re, branch)
             if m:
                 if m.group(1) == 'ubuntu':
@@ -79,3 +78,13 @@ Positional Arguments:
                 else:
                     return branch
         return ubuntu_branch
+
+    def get_origin_branches(self):
+        """ Return a list of all the branches in the "origin" remote. """
+        cmd = ['git', 'branch', '-r', '--list', 'origin/*']
+        output = subprocess.check_output(cmd)
+        if six.PY3:
+            output = output.decode('utf-8')
+        lines = output.split("\n")
+        branches = [line.strip()[7:] for line in lines]
+        return branches

--- a/rhcephpkg/tests/test_checkout_from_patches.py
+++ b/rhcephpkg/tests/test_checkout_from_patches.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import six
 import pytest
 from rhcephpkg.checkout_from_patches import CheckoutFromPatches
 from rhcephpkg.tests.util import CallRecorder
@@ -6,18 +8,24 @@ from rhcephpkg.tests.util import CallRecorder
 
 class TestCheckoutFromPatches(object):
 
-    @pytest.fixture(autouse=True)
-    def fake_clone(self, tmpdir, monkeypatch):
-        """ Fake just enough of a git clone. """
-        origin = tmpdir.join('.git/refs/remotes/origin')
+    @pytest.fixture
+    def testpkg(self, testpkg):
+        """
+        Override the testpkg fixture with remote refs.
+        """
+        origin = testpkg.join('.git/refs/remotes/origin')
+        output = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+        sha = output.rstrip()
+        if six.PY3:
+            sha = output.decode('utf-8').rstrip()
         branches = ['ceph-2-xenial',
                     'ceph-3.0-ubuntu',
                     'ceph-2-ubuntu-hotfix-bz123',
                     'private-kdreyer-ceph-2-ubuntu-test-bz456']
         os.makedirs(str(origin))
         for branch in branches:
-            origin.mkdir(branch)
-        monkeypatch.chdir(tmpdir)
+            origin.join(branch).write(sha)
+        return testpkg
 
     @pytest.mark.parametrize('patches_branch,expected', [
         ('ceph-2-rhel-patches', 'ceph-2-xenial'),
@@ -27,26 +35,26 @@ class TestCheckoutFromPatches(object):
          'private-kdreyer-ceph-2-ubuntu-test-bz456'),
         ('ceph-4.0-rhel-patches', None),
     ])
-    def test_get_debian_branch(self, patches_branch, expected):
+    def test_get_debian_branch(self, testpkg, patches_branch, expected):
         cfp = CheckoutFromPatches(['checkout-from-patches', patches_branch])
         result = cfp.get_debian_branch(patches_branch)
         assert result == expected
 
-    def test_no_args(self, capsys):
+    def test_no_args(self, testpkg, capsys):
         cfp = CheckoutFromPatches(['checkout-from-patches'])
         with pytest.raises(SystemExit):
             cfp.main()
         out, _ = capsys.readouterr()
         assert cfp._help in out
 
-    def test_help(self, capsys):
+    def test_help(self, testpkg, capsys):
         cfp = CheckoutFromPatches(['checkout-from-patches', '--help'])
         with pytest.raises(SystemExit):
             cfp.main()
         out, _ = capsys.readouterr()
         assert cfp._help in out
 
-    def test_checkout(self, tmpdir, monkeypatch):
+    def test_checkout(self, testpkg, monkeypatch):
         """ Test the happy path for checking out a branch """
         recorder = CallRecorder()
         monkeypatch.setattr('subprocess.check_call', recorder)
@@ -55,7 +63,7 @@ class TestCheckoutFromPatches(object):
         cfp.main()
         assert recorder.args == ['git', 'checkout', 'ceph-2-xenial']
 
-    def test_bad_checkout(self):
+    def test_bad_checkout(self, testpkg):
         """ Test a branch that doesn't exist """
         argv = ['checkout-from-patches', 'ceph-4.0-rhel-patches']
         cfp = CheckoutFromPatches(argv)


### PR DESCRIPTION
In some situations (eg. a fresh git clone), the `.git/refs/remotes/` directory does not list the branches from the origin remote. I'm not sure if this is related to Git versions or something about the way I'm cloning.

Use a more official method of enumerating all the branches from the origin remote: run `git branch -r`.