### PR TITLE
checkout-from-patches: better branch matching

### DIFF
--- a/rhcephpkg/checkout_from_patches.py
+++ b/rhcephpkg/checkout_from_patches.py
@@ -70,7 +70,7 @@ Positional Arguments:
         debian_re = patches_re.sub('-([a-z]+)', patches_branch)
         ubuntu_branch = None
         for branch in self.get_origin_branches():
-            m = re.search(debian_re, branch)
+            m = re.match('^%s$' % debian_re, branch)
             if m:
                 if m.group(1) == 'ubuntu':
                     # Use this only if we could find no other distro branch.

--- a/rhcephpkg/tests/test_checkout_from_patches.py
+++ b/rhcephpkg/tests/test_checkout_from_patches.py
@@ -18,17 +18,21 @@ class TestCheckoutFromPatches(object):
         sha = output.rstrip()
         if six.PY3:
             sha = output.decode('utf-8').rstrip()
-        branches = ['ceph-2-xenial',
+        branches = ['ceph-1.3-trusty',
+                    'ceph-2-ubuntu',
+                    'patch-queue/ceph-2-ubuntu',
                     'ceph-3.0-ubuntu',
+                    'patch-queue/ceph-3.0-ubuntu',
                     'ceph-2-ubuntu-hotfix-bz123',
                     'private-kdreyer-ceph-2-ubuntu-test-bz456']
-        os.makedirs(str(origin))
+        os.makedirs(str(origin.join('patch-queue')))
         for branch in branches:
             origin.join(branch).write(sha)
         return testpkg
 
     @pytest.mark.parametrize('patches_branch,expected', [
-        ('ceph-2-rhel-patches', 'ceph-2-xenial'),
+        ('ceph-1.3-rhel-patches', 'ceph-1.3-trusty'),
+        ('ceph-2-rhel-patches', 'ceph-2-ubuntu'),
         ('ceph-3.0-rhel-patches', 'ceph-3.0-ubuntu'),
         ('ceph-2-rhel-patches-hotfix-bz123', 'ceph-2-ubuntu-hotfix-bz123'),
         ('private-kdreyer-ceph-2-rhel-patches-test-bz456',
@@ -61,7 +65,7 @@ class TestCheckoutFromPatches(object):
         argv = ['checkout-from-patches', 'ceph-2-rhel-patches']
         cfp = CheckoutFromPatches(argv)
         cfp.main()
-        assert recorder.args == ['git', 'checkout', 'ceph-2-xenial']
+        assert recorder.args == ['git', 'checkout', 'ceph-2-ubuntu']
 
     def test_bad_checkout(self, testpkg):
         """ Test a branch that doesn't exist """


### PR DESCRIPTION
We were improperly selecting the Ubuntu branches in some cases.

Add more examples to the test suite to cover these cases.

(and correct the ceph-2-xenial -> ceph-2-ubuntu test case, because the testpkg fixture already uses the "ceph-2-ubuntu" branch.)