### PR TITLE
util: check environment vars in get_user_email()

### DIFF
--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -101,6 +101,19 @@ class TestUtilGetUserFullname(object):
 
 class TestUtilGetUserEmail(object):
 
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        monkeypatch.delenv('DEBEMAIL', raising=False)
+        monkeypatch.delenv('MAIL', raising=False)
+
+    def test_debemail_env(self, monkeypatch):
+        monkeypatch.setenv('DEBEMAIL', 'debemail@redhat.com')
+        assert util.get_user_email() == 'debemail@redhat.com'
+
+    def test_email_env(self, monkeypatch):
+        monkeypatch.setenv('EMAIL', 'plainname@redhat.com')
+        assert util.get_user_email() == 'plainname@redhat.com'
+
     def test_config(self):
         assert util.get_user_email() == 'kdreyer@redhat.com'
 

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -99,6 +99,12 @@ class TestUtilGetUserFullname(object):
         assert util.get_user_fullname() == 'Mr Gecos'
 
 
+class TestUtilGetUserEmail(object):
+
+    def test_config(self):
+        assert util.get_user_email() == 'kdreyer@redhat.com'
+
+
 class TestUtilSetupPristineTarBranch(object):
 
     def test_no_remote_branch(self, testpkg, monkeypatch):

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -92,6 +92,10 @@ def get_user_fullname():
 
 def get_user_email():
     """ Get a user's redhat email. """
+    if 'DEBEMAIL' in os.environ:
+        return os.environ['DEBEMAIL']
+    if 'EMAIL' in os.environ:
+        return os.environ['EMAIL']
     c = config()
     return c.get('rhcephpkg', 'user') + '@redhat.com'
 


### PR DESCRIPTION
If the `DEBEMAIL` or `EMAIL` environment variables are set, use that for the maintainer's email address.

This gives us fine-grained control over the email address that Jenkins will write into the changelog when automatically applying patches.