### PR TITLE
raise on bad package name

### DIFF
--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -46,6 +46,13 @@ class TestUtilPackageName(object):
     def test_package_name(self, testpkg, monkeypatch):
         assert util.package_name() == 'testpkg'
 
+    def test_bad_directory(self, testpkg, monkeypatch):
+        monkeypatch.chdir(testpkg.join('debian'))
+        with pytest.raises(RuntimeError) as e:
+            util.package_name()
+        expected = 'testpkg/debian is not the root of a git clone'
+        assert expected in str(e.value)
+
 
 class TestUtilChangelog(object):
 

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -65,7 +65,10 @@ def jenkins_connection():
 def package_name():
     """ Get the name of this dist-git package
         (just our current working directory) """
-    return os.path.basename(os.getcwd())
+    cwd = os.getcwd()
+    if not os.path.isdir(os.path.join(cwd, '.git')):
+        raise RuntimeError('%s is not the root of a git clone' % cwd)
+    return os.path.basename(cwd)
 
 
 def setup_pristine_tar_branch():


### PR DESCRIPTION
If we're not at the root of a Git clone, util.package_name() will return whatever directory we happen to be in, rather than the name of the package. If we've cd'd into the "debian" directory of a package, for example, "rhcephpkg build" will tell Jenkins to to build a package named "debian".

I think Fedora's rpkg tries to be a bit more clever here with parsing the Git remote URL and so on, but that has its own problems. Let's keep it simple for now and just pessimistically raise in this case.