### PR TITLE
patch: improve check for modified .patch files

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -205,7 +205,11 @@ Options:
         output = subprocess.check_output(cmd)
         if six.PY3:
             output = output.decode('utf-8')
-        return [line.split() for line in output.splitlines()]
+        result = []
+        for line in output.splitlines():
+            if line.endswith('.patch'):
+                result.append(line.split())
+        return result
 
     def read_git_debian_patches(self):
         """


### PR DESCRIPTION
If a project has a .gitignore file that ignores new .patch files in the tree, `rhcephpkg patch` will write new .patch files locally but fail to commit them to dist-git. The `debian/changelog` bump is there, and the `debian/patches/series` file change is there, but the .patch files themselves are missing from the Git commit.

Before `rhcephpkg patch` does the Git commit, it calls `read_git_debian_patches_status()` as a pre-flight sanity-check in order to verify that some .patch file has changed.

Prior to this commit, `read_git_debian_patches_status()` would return any change to the `debian/patches/series` file as well as any .patch files.  This means that the pre-flight check would pass, even if Git was not going to commit the new .patch files themselves.

Make `read_git_debian_patches_status()` explicitly check for .patch file changes (implicitly ignoring the `debian/patches/series` file changes).

This will lead `rhcephpkg patch` to quit with an error if a .gitignore file happens to be ignoring .patch files.