### PR TITLE
build: custom Jenkins class for watching builds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,39 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Parts of rhcephpkg/jenkins.py are from the python-jenkins project, available
+under the 3-clause BSD license:
+
+Software License Agreement (BSD License)
+
+Copyright (c) 2010, Willow Garage, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+ * Neither the name of Willow Garage, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/rhcephpkg/build.py
+++ b/rhcephpkg/build.py
@@ -1,17 +1,9 @@
+from time import sleep
 from tambo import Transport
 import posixpath
-from pkg_resources import get_distribution, parse_version
-import types
 import rhcephpkg.log as log
 import rhcephpkg.util as util
-
-
-def _build_job_fixed(self, name, parameters, token):
-    """ Workaround for https://bugs.launchpad.net/bugs/1177831 """
-    import urllib2  # NOQA
-    # Note the final empty string argument here:
-    return self.jenkins_open(urllib2.Request(
-        self.build_job_url(name, parameters, token), ''))
+from rhcephpkg.watch_build import WatchBuild
 
 
 class Build(object):
@@ -49,16 +41,21 @@ Build a package in Jenkins.
                  posixpath.join(jenkins.url, 'job', 'build-package'))
         job_params = {'PKG_NAME': pkg_name, 'BRANCH': branch_name}
 
-        if self._has_broken_build_job():
-            jenkins.build_job = types.MethodType(_build_job_fixed, jenkins)
+        queue_number = jenkins.build_job('build-package',
+                                         parameters=job_params,
+                                         token=jenkins.password)
 
-        jenkins.build_job('build-package', parameters=job_params,
-                          token=jenkins.password)
+        # Job is now queued, not yet running.
+        log.info('Waiting for build queue #%d' % queue_number)
+        log.info('This may be safely interrupted...')
+        queue_item = jenkins.get_queue_item(queue_number)
+        while 'executable' not in queue_item:
+            log.info('queue state: %s' % queue_item['why'])
+            sleep(2)
+            queue_item = jenkins.get_queue_item(queue_number)
 
-    def _has_broken_build_job(self):
-        # Ubuntu Trusty ships python-jenkins 0.2.1-0ubuntu1, and this version
-        # has a broken build_job() method. See
-        # https://bugs.launchpad.net/bugs/1177831 .
-        # This bug was fixed in python-jenkins v0.3.2 upstream.
-        v = get_distribution('python_jenkins').version
-        return parse_version(v) < parse_version('0.3.2')
+        # Job is now running.
+        build_number = queue_item['executable']['number']
+        # Pass the rest over to the "watch-build" command.
+        watcher = WatchBuild(['watch'])
+        watcher.watch(build_number)

--- a/rhcephpkg/jenkins.py
+++ b/rhcephpkg/jenkins.py
@@ -1,0 +1,179 @@
+# Parts of this file are from the python-jenkins project.
+
+# The purpose of this custom module is to provide methods that are not yet in
+# python-jenkins upstream: https://launchpad.net/bugs/1724932
+# This allows the "rhcephpkg build" command to log detailed information about
+# the Jenkins builds it initiates.
+
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2010, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import
+
+import json
+import six
+import socket
+from jenkins import Jenkins
+from jenkins import JenkinsException
+from jenkins import EmptyResponseException, NotFoundException, TimeoutException
+from six.moves.urllib.error import HTTPError
+from six.moves.urllib.error import URLError
+from six.moves.urllib.request import Request, urlopen
+
+Q_ITEM = 'queue/item/%(number)d/api/json'
+
+
+class RhcephpkgJenkins(Jenkins):
+    """ Custom behavior for python-jenkins.
+
+    * Add new .jenkins_urlopen() method.
+    * Modify .jenkins_open() method to use .jenkins_urlopen().
+    * Modify .build_job() method to return a queue ID number.
+      (and ensure https://bugs.launchpad.net/bugs/1177831 is resolved.)
+    * Add new .get_queue_item() method.
+    """
+
+    def jenkins_urlopen(self, req, add_crumb=True):
+        '''Utility routine for opening an HTTP request to a Jenkins server.
+
+        This should only be used to extends the :class:`Jenkins` API.
+
+        :param req: A ``six.moves.urllib.request.Request`` to submit.
+        :param add_crumb: If True, try to add a crumb header to this ``req``
+                          before submitting. Defaults to ``True``.
+        :returns: A file-like object from urlopen()
+        '''
+        try:
+            if self.auth:
+                req.add_header('Authorization', self.auth)
+            if add_crumb:
+                self.maybe_add_crumb(req)
+            response = urlopen(req, timeout=self.timeout)
+            if response is None:
+                raise EmptyResponseException(
+                    "Error communicating with server[%s]: "
+                    "empty response" % self.server)
+            return response
+        except HTTPError as e:
+            # Jenkins's funky authentication means its nigh impossible to
+            # distinguish errors.
+            if e.code in [401, 403, 500]:
+                # six.moves.urllib.error.HTTPError provides a 'reason'
+                # attribute for all python version except for ver 2.6
+                # Falling back to HTTPError.msg since it contains the
+                # same info as reason
+                raise JenkinsException(
+                    'Error in request. ' +
+                    'Possibly authentication failed [%s]: %s' % (
+                        e.code, e.msg)
+                )
+            elif e.code == 404:
+                raise NotFoundException('Requested item could not be found')
+            else:
+                raise
+        except socket.timeout as e:
+            raise TimeoutException('Error in request: %s' % (e))
+        except URLError as e:
+            # python 2.6 compatibility to ensure same exception raised
+            # since URLError wraps a socket timeout on python 2.6.
+            if str(e.reason) == "timed out":
+                raise TimeoutException('Error in request: %s' % (e.reason))
+            raise JenkinsException('Error in request: %s' % (e.reason))
+
+    def jenkins_open(self, req, add_crumb=True):
+        '''Return the HTTP response body from an HTTP ``Request``.
+
+        This should only be used to extends the :class:`Jenkins` API.
+        '''
+        response = self.jenkins_urlopen(req, add_crumb)
+        content = response.read()
+        if content is None:
+            raise EmptyResponseException(
+                "Error communicating with server[%s]: "
+                "empty response" % self.server)
+        return content.decode('utf-8')
+
+    def get_queue_item(self, number):
+        '''Get information about a queued item (to-be-created job).
+
+        The returned dict will have a "why" key if the queued item is still
+        waiting for an executor.
+
+        The returned dict will have an "executable" key if the queued item is
+        running on an executor, or has completed running. Use this to
+        determine the job number / URL.
+
+        :param name: queue number, ``int``
+        :returns: dictionary of queued information, ``dict``
+        '''
+        try:
+            url = self._build_url(Q_ITEM, locals())
+            response = self.jenkins_open(Request(url))
+            if response:
+                return json.loads(response)
+            else:
+                raise JenkinsException('queue number[%d] does not exist'
+                                       % number)
+        except HTTPError:
+            raise JenkinsException('queue number[%d] does not exist' % number)
+        except ValueError:
+            raise JenkinsException(
+                'Could not parse JSON info for queue number[%d]' % number
+            )
+
+    def build_job(self, name, parameters=None, token=None):
+        '''Trigger build job.
+
+        This method returns a queue item number that you can pass to
+        :meth:`Jenkins.get_queue_item`. Note that this queue number is only
+        valid for about five minutes after the job completes, so you should
+        get/poll the queue information as soon as possible to determine the
+        job's URL.
+
+        :param name: name of job
+        :param parameters: parameters for job, or ``None``, ``dict``
+        :param token: Jenkins API token
+        :returns: ``int`` queue item
+        '''
+        response = self.jenkins_urlopen(Request(
+            self.build_job_url(name, parameters, token), b''))
+        if six.PY2:
+            location = response.info().getheader('location')
+        if six.PY3:
+            location = response.getheader('location')
+        # location is a queue item, eg. "http://jenkins/queue/item/25/"
+        if location.endswith('/'):
+            location = location[:-1]
+        parts = location.split('/')
+        number = int(parts[-1])
+        return number

--- a/rhcephpkg/tests/test_hello.py
+++ b/rhcephpkg/tests/test_hello.py
@@ -23,6 +23,7 @@ class TestHelloJenkins(object):
         # python-jenkins uses a "from" import, "from X import Y", so
         # monkeypatching is trickier.
         monkeypatch.setattr('jenkins.urlopen', fake_urlopen)
+        monkeypatch.setattr('rhcephpkg.jenkins.urlopen', fake_urlopen)
         # Another option would be to use func_code. This globally patches all
         # calls to urlopen(), not just jenkins' calls.
         # monkeypatch.setattr('six.moves.urllib.request.urlopen.func_code',

--- a/rhcephpkg/tests/test_jenkins.py
+++ b/rhcephpkg/tests/test_jenkins.py
@@ -1,0 +1,11 @@
+from rhcephpkg.jenkins import RhcephpkgJenkins
+from jenkins import Jenkins
+
+
+class TestJenkins(object):
+    def test_inheritance(self):
+        issubclass(RhcephpkgJenkins, Jenkins)
+
+    def test_constructor(self):
+        j = RhcephpkgJenkins('https://example.com/')
+        assert isinstance(j, Jenkins)

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -5,7 +5,7 @@ from textwrap import TextWrapper
 import time
 import six
 from six.moves import configparser
-from jenkins import Jenkins
+from rhcephpkg.jenkins import RhcephpkgJenkins
 
 
 def current_branch():
@@ -53,7 +53,7 @@ def jenkins_connection():
         except configparser.Error as err:
             raise SystemExit('Problem parsing .rhcephpkg.conf: %s',
                              err.message)
-        jenkins = Jenkins(url, username=user, password=token)
+        jenkins = RhcephpkgJenkins(url, username=user, password=token)
         # These "password" and "url" attributes are not formally part of
         # python-jenkins' API, but they are nice to make available to consumers
         # (for logging/debugging, for example.)


### PR DESCRIPTION
python-jenkins has a bug where `build_job()` returns nothing, https://launchpad.net/bugs/1724932

I've submitted changes to python-jenkins upstream to make it return a queue ID number, which we can query with a new `get_queue_item()` method.

Until these changes are present in the python-jenkins package in the Ubuntu distribution we support, add them to a child class `RhcephpkgJenkins`. Use this child class for builds.

This allows us to watch a build's queue ID and eventually pass the job ID over to the `watch-build` code.