### PR TITLE
watch-build: misc improvements

### DIFF
--- a/rhcephpkg/watch_build.py
+++ b/rhcephpkg/watch_build.py
@@ -59,16 +59,25 @@ For example: "rhcephpkg watch-build 328"
 
         was_building = build_info['building']
         while build_info['building']:
-            elapsed = datetime.now(jenkins_tz) - start
-            # TODO: Xenial has python-humanize (humanize.naturaldelta() here)
-            # Backport the python-humanize package for Trusty? Or drop Trusty?
-            (minutes, seconds) = divmod(elapsed.total_seconds(), 60)
-            # Clear the previous line:
-            msg = '\r%s building for %02d:%02d' % (pkg_name, minutes, seconds)
-            sys.stdout.write(msg)
-            sys.stdout.flush()
-            sleep(10)
-            build_info = jenkins.get_build_info('build-package', build_number)
+            try:
+                elapsed = datetime.now(jenkins_tz) - start
+                # TODO: Xenial has python-humanize (humanize.naturaldelta()
+                # here) Backport the python-humanize package for Trusty? Or
+                # drop Trusty?
+                (minutes, seconds) = divmod(elapsed.total_seconds(), 60)
+                # Clear the previous line:
+                msg = '\r%s building for %02d:%02d' % \
+                    (pkg_name, minutes, seconds)
+                sys.stdout.write(msg)
+                sys.stdout.flush()
+                sleep(10)
+                build_info = jenkins.get_build_info('build-package',
+                                                    build_number)
+            except KeyboardInterrupt:
+                print('')
+                log.info('continue watching with `rhcephpkg watch-build %s`' %
+                         build_number)
+                raise SystemExit()
         if was_building:
             # The above "while" loop will not print a final newline.
             print('')

--- a/rhcephpkg/watch_build.py
+++ b/rhcephpkg/watch_build.py
@@ -57,6 +57,7 @@ For example: "rhcephpkg watch-build 328"
         # start = start.astimezone(tz.tzlocal())
         log.info('Started %s' % start.strftime("%F %r %z"))
 
+        was_building = build_info['building']
         while build_info['building']:
             elapsed = datetime.now(jenkins_tz) - start
             # TODO: Xenial has python-humanize (humanize.naturaldelta() here)
@@ -68,6 +69,9 @@ For example: "rhcephpkg watch-build 328"
             sys.stdout.flush()
             sleep(10)
             build_info = jenkins.get_build_info('build-package', build_number)
+        if was_building:
+            # The above "while" loop will not print a final newline.
+            print('')
 
         end_millis = build_info['timestamp'] + build_info['duration']
         end_seconds = end_millis / 1000.0


### PR DESCRIPTION
Gracefully handle `ctrl-c` from the user

Fix STDOUT when watching an ongoing build complete