### PR TITLE
travisci: hack for flake8 3.5.0 compat

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -2,7 +2,9 @@
   
 set -euv
 
-pip install pytest-flake8
+# temporary workaround for flake8 3.5.0 compat
+# https://github.com/tholo/pytest-flake8/issues/34
+pip install git+https://github.com/jezdez/pytest-flake8.git@flake8-3.5.0
 
 pip install pytest-cov python-coveralls
 


### PR DESCRIPTION
pytest-flake8 does not yet have flake8 v3.5.0 support.

When pytest-flake8 on PyPI supports the latest version of flake8, we can revert this change.