### PR TITLE
rename "_patches" variables to "_patch_queue"

### DIFF
--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -44,11 +44,11 @@ Options:
         # Determine the names of the relevant branches
         current_branch = util.current_branch()
         debian_branch = util.current_debian_branch()
-        patches_branch = util.current_patches_branch()
+        patch_queue_branch = util.current_patch_queue_branch()
         rhel_patches_branch = self.get_rhel_patches_branch(debian_branch)
 
         # Do the merge
-        if current_branch == patches_branch:
+        if current_branch == patch_queue_branch:
             # HEAD is our patch-queue branch. Use "git pull" directly.
             # For example: "git pull --ff-only patches/ceph-2-rhel-patches"
             cmd = ['git', 'pull', '--ff-only',
@@ -63,11 +63,11 @@ Options:
             # "git fetch . \
             #  patches/ceph-2-rhel-patches:patch-queue/ceph-2-ubuntu"
             cmd = ['git', 'fetch', '.',
-                   'patches/%s:%s' % (rhel_patches_branch, patches_branch)]
+                   'patches/%s:%s' % (rhel_patches_branch, patch_queue_branch)]
             if force:
                 # Do a hard push (with "+") instead.
                 cmd = ['git', 'push', '.', '+patches/%s:%s' %
-                       (rhel_patches_branch, patches_branch)]
+                       (rhel_patches_branch, patch_queue_branch)]
         log.info(' '.join(cmd))
         subprocess.check_call(cmd)
 

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -74,17 +74,17 @@ Options:
 
         # Determine the names of the patch-queue branch and debian branch
         current_branch = util.current_branch()
-        patches_branch = util.current_patches_branch()
+        patch_queue_branch = util.current_patch_queue_branch()
         debian_branch = util.current_debian_branch()
 
         # TODO: default to fetching from upstream, the way rdopkg patch does.
 
         # Get the new sha1 to insert into the $COMMIT variable in d/rules
-        cmd = ['git', 'rev-parse', patches_branch]
+        cmd = ['git', 'rev-parse', patch_queue_branch]
         output = subprocess.check_output(cmd)
-        patches_sha1 = output.rstrip()
+        patch_queue_sha1 = output.rstrip()
         if six.PY3:
-            patches_sha1 = output.decode('utf-8').rstrip()
+            patch_queue_sha1 = output.decode('utf-8').rstrip()
 
         # Switch to "debian" branch if necessary
         if current_branch != debian_branch:
@@ -113,7 +113,7 @@ Options:
         if old_sha1:
             rules = read_rules_file()
             with open('debian/rules', 'w') as fileh:
-                fileh.write(rules.replace(old_sha1, patches_sha1))
+                fileh.write(rules.replace(old_sha1, patch_queue_sha1))
 
         # Get the new patch series
         new_series = self.read_series_file('debian/patches/series')
@@ -137,7 +137,7 @@ Options:
         # Assemble a standard commit message string "clog".
         clog = "debian: %s\n" % util.get_deb_version()
         clog += "\n"
-        clog += "Add patches from %s\n" % patches_branch
+        clog += "Add patches from %s\n" % patch_queue_branch
         clog += "\n"
         clog += util.format_changelog(changelog)
 

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -15,8 +15,8 @@ class TestUtilCurrentBranch(object):
     def test_current_debian_branch(self, testpkg, monkeypatch):
         assert util.current_debian_branch() == 'ceph-2-ubuntu'
 
-    def test_current_patches_branch(self, testpkg, monkeypatch):
-        assert util.current_patches_branch() == 'patch-queue/ceph-2-ubuntu'
+    def test_current_patch_queue_branch(self, testpkg, monkeypatch):
+        assert util.current_patch_queue_branch() == 'patch-queue/ceph-2-ubuntu'
 
 
 class TestUtilConfig(object):

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -17,7 +17,7 @@ def current_branch():
     return output
 
 
-def current_patches_branch():
+def current_patch_queue_branch():
     """ Get our patch-queue branch's name, based on the current branch """
     current = current_branch()
     if current.startswith('patch-queue/'):


### PR DESCRIPTION
In some cases I was using variables and methods named `patches` to refer to the debian `patch-queue/` branch.

This gets especially confusing in the `merge-patches` CLI sub-command, where we have to interact with a "rhel patches branch" and "patch queue" branch, and the difference between the two is very important.

Rename all the methods and variables that deal with git-buildpackage's "patch-queue/" branches to have `patch_queue` names, rather than the ambiguous `patches` names.