### PR TITLE
merge-patches: ensure local patch-queue branch exists

### DIFF
--- a/rhcephpkg/merge_patches.py
+++ b/rhcephpkg/merge_patches.py
@@ -62,6 +62,7 @@ Options:
             # patch-queue ref. For example:
             # "git fetch . \
             #  patches/ceph-2-rhel-patches:patch-queue/ceph-2-ubuntu"
+            util.ensure_patch_queue_branch()
             cmd = ['git', 'fetch', '.',
                    'patches/%s:%s' % (rhel_patches_branch, patch_queue_branch)]
             if force:

--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -19,6 +19,20 @@ class TestUtilCurrentBranch(object):
         assert util.current_patch_queue_branch() == 'patch-queue/ceph-2-ubuntu'
 
 
+class TestUtilEnsureBranch(object):
+    def test_ensure_patch_queue_branch(self, testpkg, monkeypatch):
+        remotesdir = testpkg.join('.git').join('refs').mkdir('remotes')
+        remotesdir.mkdir('origin').ensure('patch-queue/ceph-2-ubuntu',
+                                          file=True)
+        recorder = CallRecorder()
+        monkeypatch.setattr('subprocess.call', recorder)
+        util.ensure_patch_queue_branch()
+        expected = ['git', 'branch', '--force', '--track',
+                    'patch-queue/ceph-2-ubuntu',
+                    'origin/patch-queue/ceph-2-ubuntu']
+        assert recorder.args == expected
+
+
 class TestUtilConfig(object):
 
     def test_missing_config_file(self, monkeypatch, tmpdir):

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -6,6 +6,10 @@ import time
 import six
 from six.moves import configparser
 from rhcephpkg.jenkins import RhcephpkgJenkins
+try:
+    from subprocess import DEVNULL  # py3
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
 
 
 def current_branch():
@@ -33,6 +37,23 @@ def current_debian_branch():
         return current[12:]
     else:
         return current
+
+
+def ensure_local_branch(branch):
+    """
+    Ensure our local branch exists, tracks origin, and is pointed at the same
+    sha1 as the origin remote's branch.
+    """
+    cmd = ['git', 'branch', '--force', '--track', branch, 'origin/%s' % branch]
+    subprocess.call(cmd, stdout=DEVNULL, stderr=DEVNULL)
+
+
+def ensure_patch_queue_branch():
+    """
+    Ensure our local patch-queue branch exists and tracks/matches origin.
+    """
+    pq_branch = current_patch_queue_branch()
+    ensure_local_branch(pq_branch)
 
 
 def config():


### PR DESCRIPTION
Prior to this change, the "merge-patches" command would always behave like `--force` *if* no local patch-queue branch existed at all.

If the user is not on a local patch-queue branch already, ensure that one at least exists and tracks origin.

With this change, `merge-patches` (without `--force`) will fail if the merge from RHEL -> Debian is not a fast-forward merge, regardless of which branch the user happens to have checked out at the moment.