### PR TITLE
util: optimize setup_pristine_tar_branch()

### DIFF
--- a/rhcephpkg/tests/test_util.py
+++ b/rhcephpkg/tests/test_util.py
@@ -151,8 +151,8 @@ class TestUtilSetupPristineTarBranch(object):
         recorder = CallRecorder()
         monkeypatch.setattr('subprocess.call', recorder)
         util.setup_pristine_tar_branch()
-        expected = ['git', 'branch', '--track', 'pristine-tar',
-                    'origin/pristine-tar']
+        expected = ['git', 'branch', '--force', '--track',
+                    'pristine-tar', 'origin/pristine-tar']
         assert recorder.args == expected
 
     def test_remote_and_local_branches_present(self, testpkg, monkeypatch):
@@ -163,4 +163,6 @@ class TestUtilSetupPristineTarBranch(object):
         recorder = CallRecorder()
         monkeypatch.setattr('subprocess.call', recorder)
         util.setup_pristine_tar_branch()
-        assert recorder.called == 0
+        expected = ['git', 'branch', '--force', '--track',
+                    'pristine-tar', 'origin/pristine-tar']
+        assert recorder.args == expected

--- a/rhcephpkg/util.py
+++ b/rhcephpkg/util.py
@@ -39,13 +39,16 @@ def current_debian_branch():
         return current
 
 
-def ensure_local_branch(branch):
+def ensure_local_branch(branch, output=False):
     """
     Ensure our local branch exists, tracks origin, and is pointed at the same
     sha1 as the origin remote's branch.
     """
     cmd = ['git', 'branch', '--force', '--track', branch, 'origin/%s' % branch]
-    subprocess.call(cmd, stdout=DEVNULL, stderr=DEVNULL)
+    if output:
+        subprocess.call(cmd)
+    else:
+        subprocess.call(cmd, stdout=DEVNULL, stderr=DEVNULL)
 
 
 def ensure_patch_queue_branch():
@@ -98,10 +101,7 @@ def setup_pristine_tar_branch():
         # If there is no "origin/pristine-tar" branch, this package doesn't use
         # pristine-tar, and we don't care.
         return
-    if not os.path.exists('.git/refs/heads/pristine-tar'):
-        cmd = ['git', 'branch', '--track', 'pristine-tar',
-               'origin/pristine-tar']
-        subprocess.call(cmd)
+    ensure_local_branch('pristine-tar', output=True)
 
 
 def get_user_fullname():


### PR DESCRIPTION
Call our new `ensure_local_branch()` method, instead of doing the `git branch` command ourselves. This has the side effect of force-resetting pristine-tar to the origin remote now, which should reduce opportunities for that branch to accidentally diverge with multiple maintainers doing rebases on a package.

Add an option to `ensure_local_branch()` to print output or not, since
`setup_pristine_tar_branch()` previously did not send output to `/dev/null`.