### PR TITLE
tests: use testpkg fixture in localbuild test

### DIFF
--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -9,14 +9,12 @@ from rhcephpkg.tests.util import CallRecorder
 
 class TestLocalbuild(object):
     @pytest.mark.parametrize('args,expected', [
-        (['localbuild'], '--git-dist=trusty'),
+        (['localbuild'], '--git-dist=xenial'),
         (['localbuild', '--dist', 'trusty'], '--git-dist=trusty'),
         (['localbuild', '--dist', 'xenial'], '--git-dist=xenial'),
     ])
-    def test_localbuild(self, args, expected, monkeypatch):
+    def test_localbuild(self, testpkg, args, expected, monkeypatch):
         recorder = CallRecorder()
-        monkeypatch.setattr('rhcephpkg.localbuild.get_distro',
-                            lambda: 'trusty')
         monkeypatch.setattr('subprocess.check_call', recorder)
         monkeypatch.setattr('rhcephpkg.Localbuild._get_j_arg',
                             lambda *a: '-j2')


### PR DESCRIPTION
The localbuild operation calls `util.package_name()`, and this method expects to be at the root of a Git directory (as of d833d56d732cfd7dc96d2b33a6d5de089f8d621d).

This means the tests fail when running outside of rhcephpkg.git (say, in pbuilder with pybuild.)

Instead of monkeypatching further, use the testpkg fixture for this test.

This means we have to tweak the expected behavior slightly (default distro becomes "xenial" instead of "trusty"), because the debian branch is "ceph-2-ubuntu" in that fixture, and `get_distro()` returns "xenial" for that.