### PR TITLE
Revert "travisci: hack for flake8 3.5.0 compat"

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -2,9 +2,7 @@
   
 set -euv
 
-# temporary workaround for flake8 3.5.0 compat
-# https://github.com/tholo/pytest-flake8/issues/34
-pip install git+https://github.com/jezdez/pytest-flake8.git@flake8-3.5.0
+pip install pytest-flake8
 
 pip install pytest-cov python-coveralls
 


### PR DESCRIPTION
This reverts commit 196aa43d6206a2caa19894418df85584831c4256 (PR #158)

pytest-flake8 v0.9 now has support for the latest flake8 version.