### PR TITLE
patch: properly handle deleting patches

### DIFF
--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -99,14 +99,14 @@ Options:
         cmd = ['gbp', 'pq', 'export']
         subprocess.check_call(cmd)
 
+        # Add all patch files to Git's index
+        cmd = ['git', 'add', '--all', 'debian/patches']
+        subprocess.check_call(cmd)
+
         # Bail early if gbp pq did nothing.
         if not self.read_git_debian_patches_status():
             print('No new patches, quitting.')
             raise SystemExit(1)
-
-        # Add all patch files to Git's index
-        cmd = ['git', 'add', '--all', 'debian/patches']
-        subprocess.check_call(cmd)
 
         # Replace $COMMIT sha1 in d/rules
         old_sha1 = read_commit()
@@ -212,7 +212,7 @@ Options:
         result = []
         for line in output.splitlines():
             if line.endswith('.patch'):
-                result.append(line.split())
+                result.append(line.split(None, 1))
         return result
 
     def read_git_debian_patches(self):

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -171,6 +171,9 @@ Options:
                     action = 'Modified'
                 if action == 'D':
                     action = 'Deleted'
+                if action == 'R':
+                    # We don't log .patch file renames
+                    continue
                 change = '%s %s' % (action, p.path)
             except AttributeError:
                 # This was a simple patch addition, so just log the patch's

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -184,6 +184,10 @@ Options:
         return changelog
 
     def get_rhbzs(self, patch):
+        """
+        Return all RHBZ numbers from a Patch's subject and body.
+        :param patch: gbp.patch_series.Patch``
+        """
         bzs = re.findall(BZ_REGEX, patch.subject)
         bzs.extend(re.findall(BZ_REGEX, patch.long_desc))
         return bzs

--- a/rhcephpkg/patch.py
+++ b/rhcephpkg/patch.py
@@ -93,7 +93,7 @@ Options:
 
         # Get the original (old) patch series
         old_series = self.read_series_file('debian/patches/series')
-        old_subjects = map(lambda x: x.subject, old_series)
+        old_subjects = [patch.subject for patch in old_series]
 
         # Git-buildpackage pq operation
         cmd = ['gbp', 'pq', 'export']

--- a/rhcephpkg/tests/test_patch.py
+++ b/rhcephpkg/tests/test_patch.py
@@ -1,5 +1,4 @@
 from rhcephpkg import Patch
-from rhcephpkg.patch import BzNotFound
 import pytest
 from rhcephpkg.tests.util import git
 
@@ -102,8 +101,18 @@ testpkg (1.0.0-4redhat1) stable; urgency=medium
         git('reset', '--hard', 'HEAD~2')
         # But really keep the "baz" patch:
         git('cherry-pick', 'HEAD@{4}')  # this is too fragile :(
-        with pytest.raises(BzNotFound):
-            p.main()
+        p.main()
+        changelog_file = testpkg.join('debian').join('changelog')
+        # Verify we do not mention "baz" here, since it was simply
+        # rebased/renumbered:
+        expected = """
+testpkg (1.0.0-4redhat1) stable; urgency=medium
+
+  * Deleted debian/patches/0001-add-foobar-script.patch (rhbz#123)
+
+""".lstrip("\n")
+        result = changelog_file.read()
+        assert result.startswith(expected)
 
 
 class FakePatch(object):


### PR DESCRIPTION
When we deleted patches from a `patch-queue` branch, `rhcephpkg patch` would
blow up in a number of ways.

This pull request fixes the `patch` subcommand to handle this properly and adds
a unit test to verify the behavior.