### PR TITLE
add "list-builds" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,8 @@ Commands
 
 * ``rhcephpkg gitbz`` - Verify each RHBZ in the last Git commit message.
 
+* ``rhcephpkg list-builds`` - List builds for a package in chacra.
+
 * ``rhcephpkg localbuild`` - Perform a local build using pbuilder.
 
 * ``rhcephpkg merge-patches`` - Do a merge from the RHEL `rdopkg

--- a/rhcephpkg/__init__.py
+++ b/rhcephpkg/__init__.py
@@ -5,6 +5,7 @@ from .clone import Clone
 from .download import Download
 from .gitbz import Gitbz
 from .hello import Hello
+from .list_builds import ListBuilds
 from .localbuild import Localbuild
 from .merge_patches import MergePatches
 from .new_version import NewVersion
@@ -13,7 +14,7 @@ from .source import Source
 from .watch_build import WatchBuild
 
 __all__ = ['log', 'Build', 'CheckoutFromPatches', 'Clone', 'Download',
-           'Gitbz', 'Hello', 'Localbuild', 'MergePatches', 'NewVersion',
-           'Patch', 'Source', 'WatchBuild']
+           'Gitbz', 'Hello', 'ListBuilds', 'Localbuild', 'MergePatches',
+           'NewVersion', 'Patch', 'Source', 'WatchBuild']
 
 __version__ = '1.8.0'

--- a/rhcephpkg/list_builds.py
+++ b/rhcephpkg/list_builds.py
@@ -1,0 +1,71 @@
+import json
+import posixpath
+import six
+from six.moves import configparser
+from six.moves.urllib.request import Request, urlopen
+from gbp.deb import DpkgCompareVersions
+from tambo import Transport
+import rhcephpkg.util as util
+
+
+class ListBuilds(object):
+    help_menu = 'list builds for a package in chacra'
+    _help = """
+Print a sorted list of all builds (NVRs) stored in chacra for a package.
+
+This is somewhat similar to the "koji list-builds" command.
+
+Positional Arguments:
+
+[package]  The name of the package, eg "ceph"
+"""
+    name = 'list-builds'
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.options = []
+
+    def main(self):
+        self.parser = Transport(self.argv, options=self.options)
+        self.parser.catch_help = self.help()
+        self.parser.parse_args()
+        try:
+            package = self.parser.unknown_commands[0]
+        except IndexError:
+            return self.parser.print_help()
+        self._run(package)
+
+    def help(self):
+        return self._help
+
+    def _run(self, package):
+        versions = self.list_builds(package)
+        versions = self.sort_nvrs(versions)
+        nvrs = ['%s_%s' % (package, version) for version in versions]
+        print("\n".join(nvrs))
+
+    def list_builds(self, package):
+        configp = util.config()
+        try:
+            base_url = configp.get('rhcephpkg.chacra', 'url')
+        except configparser.Error as err:
+            raise SystemExit('Problem parsing .rhcephpkg.conf: %s',
+                             err.message)
+        builds_url = posixpath.join(base_url, 'binaries/', package)
+        build_response = urlopen(Request(builds_url))
+        headers = build_response.headers
+        if six.PY2:
+            encoding = headers.getparam('charset') or 'utf-8'
+            # if encoding is None:
+            #    encoding = 'utf-8'
+        else:
+            encoding = headers.get_content_charset(failobj='utf-8')
+        payload = json.loads(build_response.read().decode(encoding))
+        return payload.keys()
+
+    def sort_nvrs(self, nvrs):
+        dcmp = DpkgCompareVersions()
+        if six.PY2:
+            return sorted(nvrs, cmp=dcmp)
+        from functools import cmp_to_key
+        return sorted(nvrs, key=cmp_to_key(dcmp))

--- a/rhcephpkg/main.py
+++ b/rhcephpkg/main.py
@@ -24,6 +24,7 @@ Global Options:
         'download': rhcephpkg.Download,
         'gitbz': rhcephpkg.Gitbz,
         'hello': rhcephpkg.Hello,
+        'list-builds': rhcephpkg.ListBuilds,
         'localbuild': rhcephpkg.Localbuild,
         'merge-patches': rhcephpkg.MergePatches,
         'new-version': rhcephpkg.NewVersion,

--- a/rhcephpkg/tests/fixtures/chacra.example.com/binaries/ceph-ansible
+++ b/rhcephpkg/tests/fixtures/chacra.example.com/binaries/ceph-ansible
@@ -1,0 +1,1 @@
+{"3.0.16-2redhat1": ["ubuntu"], "3.0.14-2redhat1": ["ubuntu"]}

--- a/rhcephpkg/tests/test_list_builds.py
+++ b/rhcephpkg/tests/test_list_builds.py
@@ -1,0 +1,39 @@
+from rhcephpkg import ListBuilds
+from rhcephpkg.tests.util import fake_urlopen
+
+
+class TestListBuilds(object):
+
+    # Note these tests use Python's "sorted()", which is not the same as
+    # gbp.deb.DpkgCompareVersions, but it's good enough for this trivial test
+    # fixture data.
+
+    def test_list_builds(self, monkeypatch):
+        monkeypatch.setattr('rhcephpkg.list_builds.urlopen', fake_urlopen)
+        lb = ListBuilds(['rhcephpkg', 'ceph-ansible'])
+        versions = lb.list_builds('ceph-ansible')
+        expected = [
+            '3.0.14-2redhat1',
+            '3.0.16-2redhat1',
+        ]
+        assert sorted(versions) == expected
+
+    def test_sort_nvrs(self):
+        lb = ListBuilds(['rhcephpkg', 'ceph-ansible'])
+        versions = [
+            '3.0.16-2redhat1',
+            '3.0.14-2redhat1',
+        ]
+        sorted_versions = lb.sort_nvrs(versions)
+        assert sorted_versions == sorted(versions)
+
+    def test_main(self, monkeypatch, capsys):
+        monkeypatch.setattr('rhcephpkg.list_builds.urlopen', fake_urlopen)
+        lb = ListBuilds(['rhcephpkg', 'ceph-ansible'])
+        lb.main()
+        expected = """
+ceph-ansible_3.0.14-2redhat1
+ceph-ansible_3.0.16-2redhat1
+""".lstrip()
+        out, _ = capsys.readouterr()
+        assert out == expected


### PR DESCRIPTION
Provide a way to quickly list all the builds that chacra knows about for a given package.