### PR TITLE
travisci: ensure wget and xz are installed

### DIFF
--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -23,6 +23,14 @@ GBP_URL=${GBP_SOURCES[$GIT_BUILDPACKAGE_SOURCE]}
 GBP_FILE=$(basename ${GBP_URL})
 GBP_DIR=$(echo $GBP_FILE | sed -e "s/.tar.[gx]z$//" -e "s/_/-/")
 
+if ! type wget > /dev/null; then
+  apt-get -y install wget
+fi
+if ! type xz > /dev/null; then
+  apt-get -y install xz-utils
+fi
+
+
 wget -nc $GBP_URL
 
 if [[ "$GBP_FILE" == *.xz ]]; then


### PR DESCRIPTION
When running this script in Travis CI, these utilities are always installed.

When running the script outside of Travis CI (eg a local dev environment), these utilities are not always installed, so the script fails when it tries to download or expand the git-buildpackage release tarball.