### PR TITLE
drop Trusty and add Bionic to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ matrix:
   # Add or remove versions to match what Travis supports
   include:
     - python: '2.7'
-      env: GIT_BUILDPACKAGE_SOURCE=trusty
-    - python: '2.7'
       env: GIT_BUILDPACKAGE_SOURCE=xenial
+    - python: '3.6'
+      env: GIT_BUILDPACKAGE_SOURCE=bionic
     - python: '3.5'
       env: GIT_BUILDPACKAGE_SOURCE=master
     - python: '3.6'

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Commands
 Installing
 ----------
 
-Pre-built Ubuntu Trusty and Xenial packages are available::
+Pre-built Ubuntu Xenial packages are available::
 
   sudo apt-get update
   sudo apt-get -y install software-properties-common

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -109,25 +109,10 @@ push your changes to the internal dist-git repository::
   git push origin xenial
 
 Lastly, we also need to copy the package to the older Ubuntu distros we
-support. As of this writing, we build the package in the PPA for Xenial, and
-then I copy the artifacts to Trusty, so users can install rhcephpkg on either
-distro.
-
-To copy a Xenial build for Trusty:
-
-* Click the `Copy Packages <https://launchpad.net/~kdreyer-redhat/+archive/ubuntu/rhceph/+copy-packages>`_ link in the Launchpad UI.
-* Select the box next to your new version's (xenial) build.
-* "Destination PPA" should be the default, "This PPA".
-* "Destination series" should be "Trusty".
-* Choose the "Copy existing binaries" option (The "Rebuild" option is `broken
-  in Launchpad <https://bugs.launchpad.net/bugs/330711>`_).
-* Click the "Copy Packages" button.
-
-Once you initiate this option, Launchpad can take a few minutes to publish the
-build for trusty. You will see the change in the Launchpad UI.
+support. As of this writing, we build the package in the PPA for Xenial.
 
 At this point you should have your new rhcephpkg version available as a .deb
-for both Xenial and Trusty. You can install the new version on your system::
+for Xenial. You can install the new version on your system::
 
   sudo apt-get update
   sudo apt-get -y install rhcephpkg

--- a/rhcephpkg/watch_build.py
+++ b/rhcephpkg/watch_build.py
@@ -62,8 +62,7 @@ For example: "rhcephpkg watch-build 328"
             try:
                 elapsed = datetime.now(jenkins_tz) - start
                 # TODO: Xenial has python-humanize (humanize.naturaldelta()
-                # here) Backport the python-humanize package for Trusty? Or
-                # drop Trusty?
+                # here)
                 (minutes, seconds) = divmod(elapsed.total_seconds(), 60)
                 # Clear the previous line:
                 msg = '\r%s building for %02d:%02d' % \

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -9,12 +9,11 @@ pip install pytest-cov python-coveralls
 # Install the version from GitHub master by default.
 # Note: 0.9 is the first gbp version to include full py3 support.
 # Things like `gbp pq export` are broken on py3 before this version.
-# This is why I'm testing master on py3 for now.
 GIT_BUILDPACKAGE_SOURCE=${GIT_BUILDPACKAGE_SOURCE:-master}
 
 declare -A GBP_SOURCES
-GBP_SOURCES[trusty]=http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.6.9.tar.xz
 GBP_SOURCES[xenial]=http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.7.2.tar.xz
+GBP_SOURCES[bionic]=http://us.archive.ubuntu.com/ubuntu/pool/universe/g/git-buildpackage/git-buildpackage_0.9.8.tar.xz
 GBP_SOURCES[master]=https://github.com/agx/git-buildpackage/archive/master/git-buildpackage-master.tar.gz
 
 # Install the desired version.

--- a/travisci/install.sh
+++ b/travisci/install.sh
@@ -42,6 +42,9 @@ pushd $GBP_DIR
   # In old versions, the setuptools packaging really wants to write to
   # /etc/git-buildpackage/gpb.conf, which we cannot access without root.
   sed -i -e '/data_files/d' setup.py
+  # setuptools cannot handle utf-8 in "scripts". Affects gbp 0.9.8. Resolved
+  # in Git master May 15 2018 (ba32efc1af9e893041dc1752008329b383986786)
+  sed -i 's/ü/u/' bin/gbp-builder-mock || :
   python setup.py install
   # gbp depends on dateutil, but setuptools does not pull it in.
   # This packaging bug is fixed in git-buildpackage version 0.8.18.


### PR DESCRIPTION
rhcephpkg 1.9.0 was the first version to not support Trusty. This PR drops the rest of the Trusty stuff from Git.

We cannot fully support running a debian-packaged rhcephpkg on Bionic yet, due to some wide differences (py2 vs py3) in the git-buildpackage version 0.7.2 in Xenial and 0.9.8 in Bionic, but this gets us a little bit closer.