### PR TITLE
new-version: multiple fixes

### DIFF
--- a/rhcephpkg/changelog.py
+++ b/rhcephpkg/changelog.py
@@ -1,9 +1,7 @@
-import os
-import shutil
-import tempfile
 from gbp.deb.changelog import ChangeLog
-# TODO: move format_changelog method here, and rename to "format_changes".
-from rhcephpkg.util import format_changelog
+# TODO: move rhcephpkg.util.format_changelog method here,
+# and rename to "format_changes".  rhcephpkg.util.bump_changelog could move
+# here too.
 
 
 def distribution():
@@ -70,53 +68,6 @@ def list_changes():
     :returns: list of unwrapped strings, one per bullet ("*")
     """
     return list(changes_iterator())
-
-
-def replace_changes(changes):
-    """
-    Replace the current changes with the new ones in the most recent
-    debian/changelog entry.
-
-    :param changes: ``list`` of changes (strings)
-    """
-    old = open('debian/changelog', 'r')
-    temp = tempfile.NamedTemporaryFile(mode='w+', delete=False)
-    # Write the first two lines as-is.
-    temp.write(old.readline())  # version header line
-    temp.write(old.readline())  # empty line
-    # Insert wrapped changelog entries here.
-    temp.write(format_changelog(changes))
-    # Skip everyting up to the next blank line.
-    while old.readline() != "\n":
-        pass
-    temp.write("\n")  # retore the empty line we just skipped
-    shutil.copyfileobj(old, temp)
-    temp.close()
-    old.close()
-    os.rename(temp.name, 'debian/changelog')
-
-
-def replace_release(release):
-    """
-    Replace the latest "release" value in a debian/changelog file.
-
-    "debian_version"
-    """
-    clog = ChangeLog(filename='debian/changelog')
-    oldstr = '%s (%s) ' % (clog.name, clog.version)
-    tmpl = '{name} ({upstream_version}-{debian_version}) '
-    newstr = tmpl.format(name=clog.name,
-                         upstream_version=clog.upstream_version,
-                         debian_version=release)
-    old = open('debian/changelog', 'r')
-    temp = tempfile.NamedTemporaryFile(mode='w+', delete=False)
-    oldheader = old.readline()  # old version header line
-    newheader = oldheader.replace(oldstr, newstr)
-    temp.write(newheader)
-    shutil.copyfileobj(old, temp)
-    temp.close()
-    old.close()
-    os.rename(temp.name, 'debian/changelog')
 
 
 def git_commit_message():

--- a/rhcephpkg/changelog.py
+++ b/rhcephpkg/changelog.py
@@ -6,6 +6,18 @@ from gbp.deb.changelog import ChangeLog
 from rhcephpkg.util import format_changelog
 
 
+def distribution():
+    """
+    Return the "distribution" (eg. "stable" or "xenial") from our most recent
+    debian/changelog entry.
+
+    :returns: ``str``
+    """
+    clog = ChangeLog(filename='debian/changelog')
+    # clog['Distribution'] is from dpkg-parsechangelog.
+    return clog['Distribution']
+
+
 def changes_string():
     """
     Return the "Changes" (bulleted entries) from our most recent

--- a/rhcephpkg/new_version.py
+++ b/rhcephpkg/new_version.py
@@ -57,6 +57,14 @@ Optional Arguments:
         return self._help
 
     def _run(self, tarball, bugstr):
+        # Ensure we're on the right branch.
+        current_branch = util.current_branch()
+        debian_branch = util.current_debian_branch()
+        if current_branch != debian_branch:
+            log.error('current branch is "%s"' % current_branch)
+            log.error('debian branch is "%s"' % debian_branch)
+            raise RuntimeError('Must run `new-version` on debian branch')
+
         util.setup_pristine_tar_branch()
         self.ensure_gbp_settings()
 

--- a/rhcephpkg/tests/test_changelog.py
+++ b/rhcephpkg/tests/test_changelog.py
@@ -56,32 +56,3 @@ def test_list_changes():
         'even more cool packaging updates that take a lot of text to describe so the change wraps on multiple lines',  # noqa E510
     ]
     assert changelog.list_changes() == expected
-
-
-def test_replace_changes(pkgdir):
-    changelog.replace_changes(['update to 1.1.0 (rhbz#456)'])
-    clog = pkgdir.join('debian').join('changelog')
-    contents = clog.read()
-    expected = """
-testpkg (1.1.0-1) stable; urgency=medium
-
-  * update to 1.1.0 (rhbz#456)
-
- -- Ken Dreyer <kdreyer@redhat.com>  Tue, 06 Jun 2017 14:46:37 -0600
-
-testpkg (1.0.0-2redhat1) stable; urgency=medium
-
-  * update to 1.0.0 (rhbz#123)
-
- -- Ken Dreyer <kdreyer@redhat.com>  Mon, 05 Jun 2017 13:45:36 -0600
-""".lstrip("\n")
-    assert contents == expected
-
-
-def test_replace_release(pkgdir):
-    changelog.replace_release('2redhat1')
-    clog = pkgdir.join('debian').join('changelog')
-    contents = clog.readlines(cr=False)
-    firstline = contents[0]
-    expected = "testpkg (1.1.0-2redhat1) stable; urgency=medium"
-    assert firstline == expected

--- a/rhcephpkg/tests/test_changelog.py
+++ b/rhcephpkg/tests/test_changelog.py
@@ -29,6 +29,10 @@ testpkg (1.0.0-2redhat1) stable; urgency=medium
     return tmpdir
 
 
+def test_distribution():
+    assert changelog.distribution() == 'stable'
+
+
 def test_changes_string():
     expected = """
    * update to 1.1.0

--- a/rhcephpkg/tests/test_new_version.py
+++ b/rhcephpkg/tests/test_new_version.py
@@ -68,29 +68,14 @@ def test_import_orig_tarball(monkeypatch):
     assert recorder.args == expected
 
 
-def test_run_dch(monkeypatch):
+def test_run_dch(testpkg, monkeypatch):
     recorder = CallRecorder()
     monkeypatch.setattr('subprocess.check_call', recorder)
     nv = NewVersion(['rhcephpkg'])
-    nv.run_dch()
-    expected = ['gbp', 'dch', '--auto', '-R', '--spawn-editor=never']
+    nv.run_dch('1.0', 'rhbz#123')
+    text = 'Imported Upstream version 1.0 (rhbz#123)'
+    expected = ['dch', '-D', 'xenial', '-v', '1.0-2redhat1', text]
     assert recorder.args == expected
-
-
-def test_insert_rhbzs(testpkg):
-    nv = NewVersion(['rhcephpkg'])
-    bugstr = 'rhbz#445566'
-    nv.insert_rhbzs(bugstr)
-    clog = testpkg.join('debian').join('changelog')
-    contents = clog.read()
-    expected = """
-testpkg (1.0.0-2redhat1) xenial; urgency=low
-
-  * Initial package (rhbz#445566)
-
- -- Ken Dreyer <kdreyer@redhat.com>  Tue, 06 Jun 2017 14:46:37 -0600
-""".lstrip("\n")
-    assert contents == expected
 
 
 def test_commit(testpkg, capfd):


### PR DESCRIPTION
This pull request fixes some bugs and features for `rhcephpkg new-version`.

* Properly handle gbp's `upstream-vcs-tag` setting (like with ceph).

* Correctly handle upstream versions with `~` in them (like ceph-ansible's
  betas and RCs).

* Ensure the current branch is the debian dist-git branch.