### PR TITLE
watch-build: keyboard interrupt exits with non-zero

### DIFF
--- a/rhcephpkg/watch_build.py
+++ b/rhcephpkg/watch_build.py
@@ -76,7 +76,7 @@ For example: "rhcephpkg watch-build 328"
                 print('')
                 log.info('continue watching with `rhcephpkg watch-build %s`' %
                          build_number)
-                raise SystemExit()
+                raise SystemExit(1)
         if was_building:
             # The above "while" loop will not print a final newline.
             print('')


### PR DESCRIPTION
Prior to this change, if I was watching a build and ctrl-c'd out of it,
rhcephpkg would exit with a zero exit code

That meant that if I had the following shell command set up:

  rhcephpkg watch-build 482 && git push

... and then ctrl-c'd out of "watch-build", the "git push" would still
happen, too early than what I expected.

Make ctrl-c cause "watch-build" to exit with a non-zero exit code so any
chained commands with "&&" will not proceed.