### PR TITLE
tests: assert failed builds exit non-zero code

### DIFF
--- a/rhcephpkg/tests/test_watch_build.py
+++ b/rhcephpkg/tests/test_watch_build.py
@@ -61,5 +61,6 @@ class TestWatchBuild(object):
         monkeypatch.setattr('jenkins.Jenkins.get_build_info',
                             fake_jenkins.get_build_info)
         watch_build = WatchBuild(['watch-build', 123])
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as excinfo:
             watch_build.main()
+        assert excinfo.value.code == 1


### PR DESCRIPTION
Prior to this change, we did not check the specific exit codes in the watch build failure test.

Ensure that a failed build causes rhcephpkg to exit with a non-zero exit code, since I'm relying on this specific behavior (eg. when chaining shell commands)