### PR TITLE
setup.py: better pypi upload process

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -21,12 +21,8 @@ pushes the tag and change to the origin remote::
 
   python setup.py release
 
-The final ``git push origin master`` will fail because TravisCI has not passed
-the "version bump commit" yet, and it has a strict gate on the master branch.
-This is annoying and I have not made ``setup.py`` work around it yet. I just
-run ``sleep 5m && git push`` at the end. This hack allows TravisCI to
-build/pass on the Git tag ref first, and then I'm allowed to push the same
-commit ref to master.
+This takes a while for Travis CI to build the "version bump commit", and
+GitHub has a strict gate for pushes to the master branch.
 
 At the end of this first step, you should have a shiny new tag on the master
 branch and a tarball in PyPI. https://pypi.python.org/pypi/rhcephpkg

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from time import sleep
 import os
 import re
 import subprocess
@@ -82,6 +83,13 @@ class ReleaseCommand(Command):
         cmd = ['git', 'push', 'origin', tag_name]
         print(' '.join(cmd))
         subprocess.check_call(cmd)
+
+        # Wait for CI to build this tag, so we can push directly to master
+        print('waiting 5 min for Travis CI to mark %s as green' % tag_name)
+        # XXX this long sleep is racy. It would be better to poll
+        # https://api.github.com/repos/red-hat-storage/rhcephpkg/commits/:ref/status
+        # https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        sleep(5 * 60)
 
         # Push master to the remote
         cmd = ['git', 'push', 'origin', 'master']

--- a/setup.py
+++ b/setup.py
@@ -83,15 +83,28 @@ class ReleaseCommand(Command):
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 
-        # Push package to pypi
-        cmd = ['python', 'setup.py', 'sdist', 'upload']
-        if self.sign:
-            cmd.append('--sign')
+        # Push master to the remote
+        cmd = ['git', 'push', 'origin', 'master']
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 
-        # Push master to the remote
-        cmd = ['git', 'push', 'origin', 'master']
+        # Create source package
+        cmd = ['python', 'setup.py', 'sdist']
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+        tarball = 'dist/%s-%s.tar.gz' % ('rhcephpkg', version)
+
+        # GPG sign
+        if self.sign:
+            cmd = ['gpg2', '-b', '-a', tarball]
+            print(' '.join(cmd))
+            subprocess.check_call(cmd)
+
+        # Upload
+        cmd = ['twine', 'upload', tarball]
+        if self.sign:
+            cmd.append(tarball + '.asc')
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
Use gpg2 for signing and Twine for uploading.

Sleep before pushing to master.