### PR TITLE
build: catch KeyboardInterrupt when watching queued build

### DIFF
--- a/rhcephpkg/build.py
+++ b/rhcephpkg/build.py
@@ -50,9 +50,16 @@ Build a package in Jenkins.
         log.info('This may be safely interrupted...')
         queue_item = jenkins.get_queue_item(queue_number)
         while 'executable' not in queue_item:
-            log.info('queue state: %s' % queue_item['why'])
-            sleep(2)
-            queue_item = jenkins.get_queue_item(queue_number)
+            try:
+                log.info('queue state: %s' % queue_item['why'])
+                sleep(2)
+                queue_item = jenkins.get_queue_item(queue_number)
+            except KeyboardInterrupt:
+                # We have no build_number, so just print a general message with
+                # a basic URL for the user to check.
+                print('')
+                print('Build is queued for starting at %s' % jenkins.url)
+                raise SystemExit(1)
 
         # Job is now running.
         build_number = queue_item['executable']['number']


### PR DESCRIPTION
Prior to this change, when "rhcephpkg build" was watching a queued job, and the job had not yet started, and the user hit ctrl-c, we would crash with KeyboardInterrupt.

Catch this interrupt and print a helpful message to the user, like we do for "watch-build".