### PR TITLE
tests: use raw string for "\d"

### DIFF
--- a/rhcephpkg/tests/test_localbuild.py
+++ b/rhcephpkg/tests/test_localbuild.py
@@ -57,7 +57,7 @@ class TestGetJArg(object):
         # basically re-implementing the entire code here to get the exact
         # expected result, just pattern-match for basic sanity.
         result = localbuild._get_j_arg(cpus=1)
-        assert re.match('-j\d+$', result)
+        assert re.match(r'-j\d+$', result)
 
 
 class TestSetupPbuilderCache(object):


### PR DESCRIPTION
Python 3.7 and latest versions of flake8 warn about the "\d" here because it was not in a raw string.